### PR TITLE
Lookup validation rule shall support @CtxName/Default@ annotation #585

### DIFF
--- a/src/main/java/de/metas/ui/web/address/AddressRegionLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/address/AddressRegionLookupDescriptor.java
@@ -12,6 +12,8 @@ import org.compiere.model.I_C_Location;
 import org.compiere.model.I_C_Region;
 import org.compiere.util.CCache;
 import org.compiere.util.CCache.CCacheStats;
+import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Env;
 
 import com.google.common.collect.ImmutableList;
@@ -41,26 +43,26 @@ import de.metas.ui.web.window.model.lookup.LookupDataSourceFetcher;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
 public class AddressRegionLookupDescriptor implements LookupDescriptor, LookupDataSourceFetcher
 {
-	private static final Optional<String> LookupTableName = Optional.of(I_C_Region.Table_Name); 
+	private static final Optional<String> LookupTableName = Optional.of(I_C_Region.Table_Name);
 	private static final String CACHE_PREFIX = I_C_Region.Table_Name;
 	private static final String CONTEXT_LookupTableName = I_C_Region.Table_Name;
-	private static final Set<String> PARAMETERS = ImmutableSet.of(
-			I_C_Location.COLUMNNAME_C_Country_ID //
-			, LookupDataSourceContext.PARAM_Filter.getName() //
-			, LookupDataSourceContext.PARAM_Offset.getName() //
-			, LookupDataSourceContext.PARAM_Limit.getName() //
-	);
+
+	private static final Set<CtxName> PARAMETERS = ImmutableSet.of(
+			CtxNames.parse(I_C_Location.COLUMNNAME_C_Country_ID),
+			LookupDataSourceContext.PARAM_Filter,
+			LookupDataSourceContext.PARAM_Offset,
+			LookupDataSourceContext.PARAM_Limit);
 
 	private final CCache<Integer, LookupValuesList> regionsByCountryId = CCache.newLRUCache(CACHE_PREFIX + "RegionLookupValues", 100, 0);
 
@@ -69,18 +71,19 @@ public class AddressRegionLookupDescriptor implements LookupDescriptor, LookupDa
 	{
 		return LookupTableName;
 	}
+
 	@Override
 	public String getCachePrefix()
 	{
 		return CACHE_PREFIX;
 	}
-	
+
 	@Override
 	public boolean isCached()
 	{
 		return true;
 	}
-	
+
 	@Override
 	public List<CCacheStats> getCacheStats()
 	{
@@ -108,7 +111,7 @@ public class AddressRegionLookupDescriptor implements LookupDescriptor, LookupDa
 	@Override
 	public Set<String> getDependsOnFieldNames()
 	{
-		return PARAMETERS;
+		return CtxNames.asNames(PARAMETERS);
 	}
 
 	@Override
@@ -240,7 +243,6 @@ public class AddressRegionLookupDescriptor implements LookupDescriptor, LookupDa
 	{
 		return IntegerLookupValue.of(regionRecord.getC_Region_ID(), regionRecord.getName());
 	}
-
 
 	@Override
 	public Optional<WindowId> getZoomIntoWindowId()

--- a/src/main/java/de/metas/ui/web/address/AddressRegionLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/address/AddressRegionLookupDescriptor.java
@@ -111,7 +111,7 @@ public class AddressRegionLookupDescriptor implements LookupDescriptor, LookupDa
 	@Override
 	public Set<String> getDependsOnFieldNames()
 	{
-		return CtxNames.asNames(PARAMETERS);
+		return CtxNames.toNames(PARAMETERS);
 	}
 
 	@Override

--- a/src/main/java/de/metas/ui/web/picking/PickingSlotRow.java
+++ b/src/main/java/de/metas/ui/web/picking/PickingSlotRow.java
@@ -367,6 +367,9 @@ public final class PickingSlotRow implements IViewRow
 
 		public static final PickingSlotRowId ofHU(final int pickingSlotId, final int huId, final int huStorageProductId)
 		{
+			Preconditions.checkArgument(pickingSlotId > 0, "pickingSlotId > 0");
+			Preconditions.checkArgument(huId > 0, "huId > 0");
+
 			return new PickingSlotRowId(pickingSlotId, huId, huStorageProductId);
 		}
 

--- a/src/main/java/de/metas/ui/web/view/descriptor/SqlViewSelectionQueryBuilder.java
+++ b/src/main/java/de/metas/ui/web/view/descriptor/SqlViewSelectionQueryBuilder.java
@@ -20,6 +20,7 @@ import org.adempiere.ad.security.impl.AccessSqlStringExpression;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.DB;
 import org.slf4j.Logger;
 
@@ -84,7 +85,7 @@ public final class SqlViewSelectionQueryBuilder
 	public static final String COLUMNNAME_Paging_SeqNo = "_sel_SeqNo";
 	public static final String COLUMNNAME_Paging_Record_ID = "_sel_Record_ID";
 	public static final String COLUMNNAME_Paging_Parent_ID = "_sel_Parent_ID";
-	public static final CtxName Paging_Record_IDsPlaceholder = CtxName.parse("_sel_Record_IDs");
+	public static final CtxName Paging_Record_IDsPlaceholder = CtxNames.parse("_sel_Record_IDs");
 
 	private final SqlViewBinding _viewBinding;
 	private SqlDocumentFilterConverter _sqlDocumentFieldConverter; // lazy

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
@@ -711,7 +711,9 @@ public class DocumentEntityDescriptor
 		{
 			final DocumentFieldDependencyMap.Builder dependenciesBuilder = DocumentFieldDependencyMap.builder();
 
-			dependenciesBuilder.add(DocumentFieldDependencyMap.DOCUMENT_Readonly, getReadonlyLogic().getParameters(), DependencyType.DocumentReadonlyLogic);
+			dependenciesBuilder.add(DocumentFieldDependencyMap.DOCUMENT_Readonly, 
+					getReadonlyLogic().getParametersAsPlainStrings(), 
+					DependencyType.DocumentReadonlyLogic);
 
 			getFields().values().stream().forEach(field -> dependenciesBuilder.add(field.getDependencies()));
 			return dependenciesBuilder.build();

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
@@ -712,7 +712,7 @@ public class DocumentEntityDescriptor
 			final DocumentFieldDependencyMap.Builder dependenciesBuilder = DocumentFieldDependencyMap.builder();
 
 			dependenciesBuilder.add(DocumentFieldDependencyMap.DOCUMENT_Readonly, 
-					getReadonlyLogic().getParametersAsPlainStrings(), 
+					getReadonlyLogic().getParameterNames(), 
 					DependencyType.DocumentReadonlyLogic);
 
 			getFields().values().stream().forEach(field -> dependenciesBuilder.add(field.getDependencies()));

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
@@ -1269,9 +1269,9 @@ public final class DocumentFieldDescriptor implements Serializable
 		private DocumentFieldDependencyMap buildDependencies()
 		{
 			final DocumentFieldDependencyMap.Builder dependencyMapBuilder = DocumentFieldDependencyMap.builder()
-					.add(fieldName, getReadonlyLogicEffective().getParameters(), DependencyType.ReadonlyLogic)
-					.add(fieldName, getDisplayLogic().getParameters(), DependencyType.DisplayLogic)
-					.add(fieldName, getMandatoryLogicEffective().getParameters(), DependencyType.MandatoryLogic);
+					.add(fieldName, getReadonlyLogicEffective().getParametersAsPlainStrings(), DependencyType.ReadonlyLogic)
+					.add(fieldName, getDisplayLogic().getParametersAsPlainStrings(), DependencyType.DisplayLogic)
+					.add(fieldName, getMandatoryLogicEffective().getParametersAsPlainStrings(), DependencyType.MandatoryLogic);
 
 			final LookupDescriptor lookupDescriptor = getLookupDescriptorProvider().provideForScope(LookupScope.DocumentField);
 			if (lookupDescriptor != null)

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
@@ -1269,9 +1269,9 @@ public final class DocumentFieldDescriptor implements Serializable
 		private DocumentFieldDependencyMap buildDependencies()
 		{
 			final DocumentFieldDependencyMap.Builder dependencyMapBuilder = DocumentFieldDependencyMap.builder()
-					.add(fieldName, getReadonlyLogicEffective().getParametersAsPlainStrings(), DependencyType.ReadonlyLogic)
-					.add(fieldName, getDisplayLogic().getParametersAsPlainStrings(), DependencyType.DisplayLogic)
-					.add(fieldName, getMandatoryLogicEffective().getParametersAsPlainStrings(), DependencyType.MandatoryLogic);
+					.add(fieldName, getReadonlyLogicEffective().getParameterNames(), DependencyType.ReadonlyLogic)
+					.add(fieldName, getDisplayLogic().getParameterNames(), DependencyType.DisplayLogic)
+					.add(fieldName, getMandatoryLogicEffective().getParameterNames(), DependencyType.MandatoryLogic);
 
 			final LookupDescriptor lookupDescriptor = getLookupDescriptorProvider().provideForScope(LookupScope.DocumentField);
 			if (lookupDescriptor != null)

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
@@ -76,12 +76,6 @@ public class AutoSequenceDefaultValueExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return CtxNames.toNames(PARAMETERS);
-	}
-
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		return PARAMETERS;

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
@@ -76,9 +76,9 @@ public class AutoSequenceDefaultValueExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return CtxNames.asNames(PARAMETERS);
+		return CtxNames.toNames(PARAMETERS);
 	}
 
 	@Override

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/AutoSequenceDefaultValueExpression.java
@@ -7,6 +7,8 @@ import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.Services;
+import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 
@@ -53,7 +55,9 @@ public class AutoSequenceDefaultValueExpression implements IStringExpression
 
 	private static final String PARAMETER_AD_Client_ID = WindowConstants.FIELDNAME_AD_Client_ID;
 	private static final String PARAMETER_AD_Org_ID = WindowConstants.FIELDNAME_AD_Org_ID;
-	private static final Set<String> PARAMETERS = ImmutableSet.of(PARAMETER_AD_Client_ID, PARAMETER_AD_Org_ID);
+	private static final Set<CtxName> PARAMETERS = ImmutableSet.of(
+			CtxNames.parse(PARAMETER_AD_Client_ID),
+			CtxNames.parse(PARAMETER_AD_Org_ID));
 
 	private final String tableName;
 
@@ -62,15 +66,23 @@ public class AutoSequenceDefaultValueExpression implements IStringExpression
 		this.tableName = tableName;
 	}
 
+	/**
+	 * Returns the constant {@code "@Value@"}. Not important, just to have something not null
+	 */
 	@Override
 	public String getExpressionString()
 	{
-		// not important, just to have something not null
 		return "@Value@";
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return CtxNames.asNames(PARAMETERS);
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return PARAMETERS;
 	}

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
@@ -16,17 +16,18 @@ import org.adempiere.ad.expression.json.JsonStringExpressionSerializer;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.DBException;
 import org.adempiere.util.Check;
+import org.compiere.util.CtxName;
 import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Evaluatee;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Preconditions;
 
 import de.metas.logging.LogManager;
 import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
 import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -41,11 +42,11 @@ import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -53,10 +54,10 @@ import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue;
 @JsonSerialize(using = JsonStringExpressionSerializer.class)
 public final class SqlDefaultValueExpression<V> implements IExpression<V>
 {
-	public static final <V> SqlDefaultValueExpression<?> of(final IStringExpression stringExpression, final Class<V> valueClass)
+	public static final <V> SqlDefaultValueExpression<?> of(
+			@NonNull final IStringExpression stringExpression,
+			@NonNull final Class<V> valueClass)
 	{
-		Check.assumeNotNull(valueClass, "Parameter valueClass is not null");
-
 		if (Integer.class.equals(valueClass)
 				|| IntegerLookupValue.class.equals(valueClass))
 		{
@@ -103,10 +104,12 @@ public final class SqlDefaultValueExpression<V> implements IExpression<V>
 		V get(final ResultSet rs) throws SQLException;
 	}
 
-	private SqlDefaultValueExpression(final IStringExpression stringExpression, final Class<V> valueType, final ValueLoader<V> valueRetriever)
+	private SqlDefaultValueExpression(
+			@NonNull final IStringExpression stringExpression,
+			final Class<V> valueType,
+			final ValueLoader<V> valueRetriever)
 	{
-		super();
-		this.stringExpression = Preconditions.checkNotNull(stringExpression);
+		this.stringExpression = stringExpression;
 		this.valueClass = valueType;
 		this.noResultValue = null; // IStringExpression.EMPTY_RESULT
 		this.valueRetriever = valueRetriever;
@@ -149,7 +152,13 @@ public final class SqlDefaultValueExpression<V> implements IExpression<V>
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return stringExpression.getParametersAsPlainStrings();
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return stringExpression.getParameters();
 	}

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
@@ -152,9 +152,9 @@ public final class SqlDefaultValueExpression<V> implements IExpression<V>
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return stringExpression.getParametersAsPlainStrings();
+		return stringExpression.getParameterNames();
 	}
 
 	@Override

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
@@ -20,6 +20,7 @@ import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.MLookupFactory;
 import org.compiere.model.MLookupInfo;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Evaluatees;
 
@@ -76,11 +77,11 @@ public final class SqlLookupDescriptor implements LookupDescriptor
 		return (SqlLookupDescriptor)descriptor;
 	}
 
-	public static final CtxName SQL_PARAM_KeyId = CtxName.parse("SqlKeyId");
+	public static final CtxName SQL_PARAM_KeyId = CtxNames.parse("SqlKeyId");
 
 	public static final String SQL_PARAM_VALUE_ShowInactive_Yes = "Y"; // i.e. show all
 	public static final String SQL_PARAM_VALUE_ShowInactive_No = "N";
-	public static final CtxName SQL_PARAM_ShowInactive = CtxName.parse("SqlShowInactive/N");
+	public static final CtxName SQL_PARAM_ShowInactive = CtxNames.parse("SqlShowInactive/N");
 
 	private static final int WINDOWNO_Dummy = 99999;
 
@@ -361,7 +362,7 @@ public final class SqlLookupDescriptor implements LookupDescriptor
 				}
 
 				dependsOnFieldNames = ImmutableSet.<String> builder()
-						.addAll(validationRule.getPrefilterWhereClause().getParameters())
+						.addAll(validationRule.getPrefilterWhereClause().getParametersAsPlainStrings())
 						.addAll(validationRule.getPostQueryFilter().getParameters())
 						.build();
 			}

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
@@ -362,7 +362,7 @@ public final class SqlLookupDescriptor implements LookupDescriptor
 				}
 
 				dependsOnFieldNames = ImmutableSet.<String> builder()
-						.addAll(validationRule.getPrefilterWhereClause().getParametersAsPlainStrings())
+						.addAll(validationRule.getPrefilterWhereClause().getParameterNames())
 						.addAll(validationRule.getPostQueryFilter().getParameters())
 						.build();
 			}

--- a/src/main/java/de/metas/ui/web/window/model/lookup/GenericSqlLookupDataSourceFetcher.java
+++ b/src/main/java/de/metas/ui/web/window/model/lookup/GenericSqlLookupDataSourceFetcher.java
@@ -44,11 +44,11 @@ import lombok.NonNull;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -78,7 +78,6 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 	private GenericSqlLookupDataSourceFetcher(final LookupDescriptor lookupDescriptor)
 	{
 		super();
-		
 		// NOTE: don't store a reference to our descriptor, just extract what we need!
 
 		Preconditions.checkNotNull(lookupDescriptor);
@@ -90,9 +89,9 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 		sqlForFetchingExpression = sqlLookupDescriptor.getSqlForFetchingExpression();
 		sqlForFetchingDisplayNameByIdExpression = sqlLookupDescriptor.getSqlForFetchingDisplayNameByIdExpression();
 		postQueryPredicate = sqlLookupDescriptor.getPostQueryPredicate();
-		
+
 		isTranslatable = sqlForFetchingDisplayNameByIdExpression.requiresParameter(LookupDataSourceContext.PARAM_AD_Language.getName());
-		
+
 		zoomIntoWindowId = lookupDescriptor.getZoomIntoWindowId();
 	}
 
@@ -113,7 +112,7 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 		// NOTE: it's very important to have the lookupTableName as cache name prefix because we want the cache invalidation to happen for this table
 		return lookupTableName;
 	}
-	
+
 	@Override
 	public Optional<String> getLookupTableName()
 	{
@@ -125,13 +124,13 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 	{
 		return zoomIntoWindowId;
 	}
-	
+
 	@Override
 	public boolean isCached()
 	{
 		return false;
 	}
-	
+
 	@Override
 	public List<CCacheStats> getCacheStats()
 	{
@@ -182,8 +181,8 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 				debugProperties.put("debug-sql", sqlForFetching);
 				debugProperties.put("debug-params", evalCtx.toString());
 			}
-			
-			LookupValuesList values = data.fetchAll()
+
+			final LookupValuesList values = data.fetchAll()
 					.stream()
 					.filter(evalCtx::acceptItem)
 					.map(namePair -> LookupValue.fromNamePair(namePair, adLanguage))
@@ -209,9 +208,9 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 		{
 			return LOOKUPVALUE_NULL;
 		}
-		
+
 		final ITranslatableString displayNameTrl;
-		if(isTranslatable)
+		if (isTranslatable)
 		{
 			final String adLanguage = evalCtx.getAD_Language();
 			displayNameTrl = ImmutableTranslatableString.singleLanguage(adLanguage, displayName);

--- a/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
+++ b/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
@@ -18,6 +19,7 @@ import org.adempiere.ad.validationRule.INamePairPredicate;
 import org.adempiere.ad.validationRule.IValidationContext;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
@@ -29,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 
 import de.metas.ui.web.window.descriptor.sql.SqlLookupDescriptor;
 import de.metas.ui.web.window.model.lookup.LookupValueFilterPredicates.LookupValueFilterPredicate;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -43,11 +46,11 @@ import de.metas.ui.web.window.model.lookup.LookupValueFilterPredicates.LookupVal
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -66,7 +69,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 	{
 		return new Builder(lookupTableName);
 	}
-	
+
 	public static final Builder builderWithoutTableName()
 	{
 		return new Builder(null);
@@ -75,13 +78,13 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 	public static final String FILTER_Any = "%";
 	private static final String FILTER_Any_SQL = "'%'";
 
-	public static final CtxName PARAM_AD_Language = CtxName.parse(Env.CTXNAME_AD_Language);
+	public static final CtxName PARAM_AD_Language = CtxNames.parse(Env.CTXNAME_AD_Language);
 	private static final CtxName PARAM_UserRolePermissionsKey = AccessSqlStringExpression.PARAM_UserRolePermissionsKey;
 
-	public static final CtxName PARAM_Filter = CtxName.parse("Filter");
-	public static final CtxName PARAM_FilterSql = CtxName.parse("FilterSql");
-	public static final CtxName PARAM_Offset = CtxName.parse("Offset/0");
-	public static final CtxName PARAM_Limit = CtxName.parse("Limit/1000");
+	public static final CtxName PARAM_Filter = CtxNames.parse("Filter");
+	public static final CtxName PARAM_FilterSql = CtxNames.parse("FilterSql");
+	public static final CtxName PARAM_Offset = CtxNames.parse("Offset/0");
+	public static final CtxName PARAM_Limit = CtxNames.parse("Limit/1000");
 
 	private final String lookupTableName;
 	private final ImmutableMap<String, Object> parameterValues;
@@ -147,22 +150,21 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 	{
 		return get_ValueAsString(PARAM_Filter.getName());
 	}
-	
+
 	public String getFilterOrIfAny(final String whenAnyFilter)
 	{
 		final String filterStr = getFilter();
-		if(filterStr == FILTER_Any)
+		if (filterStr == FILTER_Any)
 		{
 			return whenAnyFilter;
 		}
 		return filterStr;
 	}
 
-	
 	public LookupValueFilterPredicate getFilterPredicate()
 	{
 		final String filterStr = getFilter();
-		if(filterStr == FILTER_Any)
+		if (filterStr == FILTER_Any)
 		{
 			return LookupValueFilterPredicates.MATCH_ALL;
 		}
@@ -263,7 +265,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		private INamePairPredicate postQueryPredicate = INamePairPredicate.NULL;
 		private final Map<String, Object> name2value = new HashMap<>();
 		private Object idToFilter;
-		private Collection<String> _requiredParameters;
+		private Collection<CtxName> _requiredParameters;
 		private boolean _requiredParameters_copyOnAdd = false;
 
 		private final Map<String, Object> valuesCollected = new LinkedHashMap<>();
@@ -301,14 +303,14 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			//
 			// Collect all values required by the post-query predicate
 			// failIfNotFound=false because it might be that NOT all postQueryPredicate's parameters are mandatory!
-			collectContextValues(postQueryPredicate.getParameters(), false);
+			collectContextValues(CtxNames.parseStrings(postQueryPredicate.getParameters()), false);
 
 			//
 			// Build the effective context
 			return new LookupDataSourceContext(lookupTableName, valuesCollected, idToFilter, postQueryPredicate);
 		}
 
-		private Collection<String> getRequiredParameters()
+		private Collection<CtxName> getRequiredParameters()
 		{
 			return _requiredParameters;
 		}
@@ -318,9 +320,9 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		 * 
 		 * NOTE: previous required parameters, if any, will be lost.
 		 * 
-		 * @param requiredParameters
+		 * @param requiredParameters the required parameters which might also contain default values to fall back to.
 		 */
-		public Builder setRequiredParameters(final Collection<String> requiredParameters)
+		public Builder setRequiredParameters(@NonNull final Collection<CtxName> requiredParameters)
 		{
 			_requiredParameters = requiredParameters;
 			_requiredParameters_copyOnAdd = true;
@@ -332,9 +334,8 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		 *
 		 * @param requiredParameter
 		 */
-		public Builder requiresParameter(final String requiredParameter)
+		public Builder requiresParameter(@NonNull final CtxName requiredParameter)
 		{
-			Check.assumeNotEmpty(requiredParameter, "requiredParameter is not empty");
 			if (_requiredParameters != null && _requiredParameters.contains(requiredParameter))
 			{
 				// we already have the parameter => do nothing
@@ -362,7 +363,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		 */
 		public Builder requiresAD_Language()
 		{
-			requiresParameter(PARAM_AD_Language.getName());
+			requiresParameter(PARAM_AD_Language);
 			return this;
 		}
 
@@ -371,10 +372,10 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		 */
 		public Builder requiresFilterAndLimit()
 		{
-			requiresParameter(PARAM_Filter.getName());
-			requiresParameter(PARAM_FilterSql.getName());
-			requiresParameter(PARAM_Limit.getName());
-			requiresParameter(PARAM_Offset.getName());
+			requiresParameter(PARAM_Filter);
+			requiresParameter(PARAM_FilterSql);
+			requiresParameter(PARAM_Limit);
+			requiresParameter(PARAM_Offset);
 			return this;
 		}
 
@@ -383,7 +384,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		 */
 		public Builder requiresUserRolePermissionsKey()
 		{
-			requiresParameter(PARAM_UserRolePermissionsKey.getName());
+			requiresParameter(PARAM_UserRolePermissionsKey);
 			return this;
 		}
 
@@ -455,14 +456,16 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			return this;
 		}
 
-		private Builder collectContextValues(final Collection<String> parameters, final boolean failIfNotFound)
+		private Builder collectContextValues(
+				@Nullable final Collection<CtxName> parameters, 
+				final boolean failIfNotFound)
 		{
 			if (parameters == null || parameters.isEmpty())
 			{
 				return this;
 			}
 
-			for (final String parameterName : parameters)
+			for (final CtxName parameterName : parameters)
 			{
 				collectContextValue(parameterName, failIfNotFound);
 			}
@@ -470,9 +473,11 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			return this;
 		}
 
-		private void collectContextValue(final String variableName, final boolean failIfNotFound)
+		private void collectContextValue(
+				@NonNull final CtxName variableName,
+				final boolean failIfNotFound)
 		{
-			if (valuesCollected.containsKey(variableName))
+			if (valuesCollected.containsKey(variableName.getName()))
 			{
 				return;
 			}
@@ -487,35 +492,39 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			}
 			else
 			{
-				valuesCollected.put(variableName, value);
+				valuesCollected.put(variableName.getName(), value);
 			}
 		}
 
-		private final Object findContextValueOrNull(final String variableName)
+		private final Object findContextValueOrNull(@NonNull final CtxName variableName)
 		{
 			//
 			// Check given parameters
-			if (name2value.containsKey(variableName))
+			if (name2value.containsKey(variableName.getName()))
 			{
-				final Object valueObj = name2value.get(variableName);
+				final Object valueObj = name2value.get(variableName.getName());
 				if (valueObj != null)
 				{
 					return valueObj;
 				}
 			}
 
-			//
 			// Fallback to document evaluatee
 			if (parentEvaluatee != null)
 			{
-				final Object value = parentEvaluatee.get_ValueAsObject(variableName);
+				final Object value = parentEvaluatee.get_ValueAsObject(variableName.getName());
 				if (value != null)
 				{
 					return value;
 				}
 			}
 
-			//
+			// Fallback to the variableName's default value
+			if (variableName.getDefaultValue() != CtxNames.VALUE_NULL)
+			{
+				return variableName.getDefaultValue();
+			}
+
 			// Value not found
 			return null;
 		}

--- a/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
+++ b/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
@@ -303,7 +303,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			//
 			// Collect all values required by the post-query predicate
 			// failIfNotFound=false because it might be that NOT all postQueryPredicate's parameters are mandatory!
-			collectContextValues(CtxNames.parseStrings(postQueryPredicate.getParameters()), false);
+			collectContextValues(CtxNames.parseAll(postQueryPredicate.getParameters()), false);
 
 			//
 			// Build the effective context


### PR DESCRIPTION
Make use of CtxNames (and their default values) in IExpressions
..mostly in LookupDataSourceContext

Also 
* adapt to the API changes made in metasfresh
* do a bit of cleanup

Lookup validation rule shall support @CtxName/Default@ annotation
https://github.com/metasfresh/metasfresh-webui-api/issues/585