### PR TITLE
#863-api - fix available stock (ATP) display in sales order

### DIFF
--- a/src/main/java/de/metas/ui/web/quickinput/IQuickInputDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/quickinput/IQuickInputDescriptorFactory.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.quickinput;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
@@ -48,7 +49,11 @@ public interface IQuickInputDescriptorFactory
 	 */
 	Set<MatchingKey> getMatchingKeys();
 
-	QuickInputDescriptor createQuickInputEntityDescriptor(final DocumentType documentType, final DocumentId documentTypeId, final DetailId detailId);
+	QuickInputDescriptor createQuickInputEntityDescriptor(
+			final DocumentType documentType,
+			final DocumentId documentTypeId,
+			final DetailId detailId,
+			final Optional<Boolean> soTrx);
 
 	//
 	//

--- a/src/main/java/de/metas/ui/web/quickinput/forecastline/ForecastLineQuickInputDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/quickinput/forecastline/ForecastLineQuickInputDescriptorFactory.java
@@ -2,6 +2,7 @@ package de.metas.ui.web.quickinput.forecastline;
 
 import static org.adempiere.model.InterfaceWrapperHelper.load;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.adempiere.ad.callout.api.ICalloutField;
@@ -37,6 +38,7 @@ import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
 import de.metas.ui.web.window.descriptor.sql.ProductLookupDescriptor;
 import de.metas.ui.web.window.descriptor.sql.ProductLookupDescriptor.ProductAndAttributes;
 import de.metas.ui.web.window.descriptor.sql.SqlLookupDescriptor;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -73,23 +75,28 @@ public class ForecastLineQuickInputDescriptorFactory implements IQuickInputDescr
 	}
 
 	@Override
-	public QuickInputDescriptor createQuickInputEntityDescriptor(final DocumentType documentType, final DocumentId documentTypeId, final DetailId detailId)
+	public QuickInputDescriptor createQuickInputEntityDescriptor(
+			final DocumentType documentType,
+			final DocumentId documentTypeId,
+			final DetailId detailId,
+			@NonNull final Optional<Boolean> soTrx)
 	{
-		final DocumentEntityDescriptor entityDescriptor = createEntityDescriptor(documentType, documentTypeId, detailId);
+		final DocumentEntityDescriptor entityDescriptor = createEntityDescriptor(documentTypeId, detailId, soTrx);
 		final QuickInputLayoutDescriptor layout = createLayout(entityDescriptor);
 
 		return QuickInputDescriptor.of(entityDescriptor, layout, ForecastLineQuickInputProcessor.class);
 	}
 
 	private DocumentEntityDescriptor createEntityDescriptor(
-			final DocumentType documentType,
 			final DocumentId documentTypeId,
-			final DetailId detailId)
+			final DetailId detailId,
+			@NonNull final Optional<Boolean> soTrx)
 	{
 		return createDescriptorBuilder(documentTypeId, detailId)
 				.addField(createProductFieldBuilder())
 				.addFieldIf(QuickInputConstants.isEnablePackingInstructionsField(), () -> createPackingInstructionFieldBuilder())
 				.addField(createQuantityFieldBuilder())
+				.setIsSOTrx(soTrx)
 				.build();
 	}
 

--- a/src/main/java/de/metas/ui/web/quickinput/inout/EmptiesQuickInputDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/quickinput/inout/EmptiesQuickInputDescriptorFactory.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.quickinput.inout;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.adempiere.ad.expression.api.ConstantLogicExpression;
@@ -24,6 +25,7 @@ import de.metas.ui.web.window.descriptor.DocumentFieldDescriptor;
 import de.metas.ui.web.window.descriptor.DocumentFieldDescriptor.Characteristic;
 import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
 import de.metas.ui.web.window.descriptor.sql.SqlLookupDescriptor;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -63,18 +65,26 @@ public class EmptiesQuickInputDescriptorFactory implements IQuickInputDescriptor
 	}
 
 	@Override
-	public QuickInputDescriptor createQuickInputEntityDescriptor(final DocumentType documentType, final DocumentId documentTypeId, final DetailId detailId)
+	public QuickInputDescriptor createQuickInputEntityDescriptor(
+			final DocumentType documentType,
+			final DocumentId documentTypeId,
+			final DetailId detailId,
+			@NonNull final Optional<Boolean> soTrx)
 	{
-		final DocumentEntityDescriptor entityDescriptor = createEntityDescriptor(documentTypeId, detailId);
+		final DocumentEntityDescriptor entityDescriptor = createEntityDescriptor(documentTypeId, detailId, soTrx);
 		final QuickInputLayoutDescriptor layout = createLayout(entityDescriptor);
 		return QuickInputDescriptor.of(entityDescriptor, layout, EmptiesQuickInputProcessor.class);
 	}
 
-	private DocumentEntityDescriptor createEntityDescriptor(final DocumentId documentTypeId, final DetailId detailId)
+	private DocumentEntityDescriptor createEntityDescriptor(
+			final DocumentId documentTypeId,
+			final DetailId detailId,
+			@NonNull final Optional<Boolean> soTrx)
 	{
 		final IMsgBL msgBL = Services.get(IMsgBL.class);
 		final DocumentEntityDescriptor.Builder entityDescriptor = DocumentEntityDescriptor.builder()
 				.setDocumentType(DocumentType.QuickInput, documentTypeId)
+				.setIsSOTrx(soTrx)
 				.disableDefaultTableCallouts()
 				.setDataBinding(DocumentEntityDataBindingDescriptorBuilder.NULL)
 				// Defaults:

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
@@ -229,7 +229,7 @@ public class LayoutFactory
 		// Usually this happens when generating the single row layout for included tabs.
 		if (!layoutSectionsList.stream().anyMatch(DocumentLayoutSectionDescriptor.Builder::isNotEmpty))
 		{
-			DocumentLayoutSectionDescriptor.Builder oneLayoutSection = DocumentLayoutSectionDescriptor.builder()
+			final DocumentLayoutSectionDescriptor.Builder oneLayoutSection = DocumentLayoutSectionDescriptor.builder()
 					.addColumn(layoutGridView().getElements());
 			layoutSectionsList = ImmutableList.of(oneLayoutSection);
 		}
@@ -616,12 +616,12 @@ public class LayoutFactory
 		//
 		// Quick input
 		{
-			final boolean supportQuickInput = quickInputDescriptors.hasQuickInputEntityDescriptor( //
-					entityDescriptor.getDocumentType() //
-					, entityDescriptor.getDocumentTypeId() //
-					, entityDescriptor.getTableNameOrNull() //
-					, entityDescriptor.getDetailId() //
-			);
+			final boolean supportQuickInput = quickInputDescriptors.hasQuickInputEntityDescriptor(
+					entityDescriptor.getDocumentType(),
+					entityDescriptor.getDocumentTypeId(),
+					entityDescriptor.getTableNameOrNull(),
+					entityDescriptor.getDetailId(),
+					entityDescriptor.getIsSOTrx());
 			layoutDetail.setSupportQuickInput(supportQuickInput);
 		}
 

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
@@ -98,7 +98,7 @@ public final class SqlLookupDescriptor implements LookupDescriptor
 
 	public static final String SQL_PARAM_VALUE_ShowInactive_Yes = "Y"; // i.e. show all
 	public static final String SQL_PARAM_VALUE_ShowInactive_No = "N";
-	public static final CtxName SQL_PARAM_ShowInactive = CtxNames.parse("SqlShowInactive/N");
+	public static final CtxName SQL_PARAM_ShowInactive = CtxNames.ofNameAndDefaultValue("SqlShowInactive", SQL_PARAM_VALUE_ShowInactive_No);
 
 	private static final int WINDOWNO_Dummy = 99999;
 
@@ -294,7 +294,7 @@ public final class SqlLookupDescriptor implements LookupDescriptor
 		private boolean numericKey;
 		private Set<String> dependsOnFieldNames;
 
-		private List<IValidationRule> validationRules = new ArrayList<>();
+		private final List<IValidationRule> validationRules = new ArrayList<>();
 		private IValidationRule validationRuleEffective = NullValidationRule.instance;
 		private String sqlTableName;
 		private ICachedStringExpression sqlForFetchingExpression;

--- a/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
+++ b/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
@@ -83,8 +83,8 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 
 	public static final CtxName PARAM_Filter = CtxNames.parse("Filter");
 	public static final CtxName PARAM_FilterSql = CtxNames.parse("FilterSql");
-	public static final CtxName PARAM_Offset = CtxNames.parse("Offset/0");
-	public static final CtxName PARAM_Limit = CtxNames.parse("Limit/1000");
+	public static final CtxName PARAM_Offset = CtxNames.ofNameAndDefaultValue("Offset", "0");
+	public static final CtxName PARAM_Limit = CtxNames.ofNameAndDefaultValue("Limit", "1000");
 
 	private final String lookupTableName;
 	private final ImmutableMap<String, Object> parameterValues;
@@ -92,15 +92,13 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 	private final INamePairPredicate postQueryPredicate;
 
 	private LookupDataSourceContext(
-			final String lookupTableName //
-			, final Map<String, Object> values //
-			, final Object idToFilter //
-			, final INamePairPredicate postQueryPredicate //
-	)
+			final String lookupTableName,
+			final Map<String, Object> values,
+			final Object idToFilter,
+			final INamePairPredicate postQueryPredicate)
 	{
-		super();
 		this.lookupTableName = lookupTableName;
-		parameterValues = ImmutableMap.copyOf(values);
+		this.parameterValues = ImmutableMap.copyOf(values);
 		this.idToFilter = idToFilter;
 		this.postQueryPredicate = postQueryPredicate;
 	}
@@ -257,7 +255,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			return Integer.parseInt(idToFilterStr);
 		}
 	}
-	
+
 	public String getIdToFilterAsString()
 	{
 		return idToFilter != null ? idToFilter.toString() : null;
@@ -322,9 +320,9 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 
 		/**
 		 * Advises the builder that provided parameters shall be present the context that will be build.
-		 * 
+		 *
 		 * NOTE: previous required parameters, if any, will be lost.
-		 * 
+		 *
 		 * @param requiredParameters the required parameters which might also contain default values to fall back to.
 		 */
 		public Builder setRequiredParameters(@NonNull final Collection<CtxName> requiredParameters)
@@ -462,7 +460,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 		}
 
 		private Builder collectContextValues(
-				@Nullable final Collection<CtxName> parameters, 
+				@Nullable final Collection<CtxName> parameters,
 				final boolean failIfNotFound)
 		{
 			if (parameters == null || parameters.isEmpty())


### PR DESCRIPTION
add an optional SOTrx parameter to the quickinput framework and use it to create differently parameterized ProductLookupDescriptors for sales and purchase.

Also
* fix theproduct-quickinput-field to query by datePromised in purchase orders and preparationDate in sales orders
* use the new method CtxNames.ofNameAndDefaultValue to avoid parsing where it is not needed

fix available stock (ATP) display in sales order https://github.com/metasfresh/metasfresh-webui-api/issues/863