### PR TITLE
4798-app - AD_RefList Description shall be shown in webui

### DIFF
--- a/src/main/java/de/metas/ui/web/address/AddressCountryLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/address/AddressCountryLookupDescriptor.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableSet;
 import de.metas.adempiere.service.ICountryDAO;
 import de.metas.cache.CCache;
 import de.metas.cache.CCache.CCacheStats;
+import de.metas.i18n.IModelTranslationMap;
 import de.metas.i18n.ITranslatableString;
 import de.metas.ui.web.window.datatypes.LookupValue;
 import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
@@ -78,7 +79,7 @@ public class AddressCountryLookupDescriptor implements LookupDescriptor, LookupD
 	{
 		return true;
 	}
-	
+
 	@Override
 	public void cacheInvalidate()
 	{
@@ -150,10 +151,10 @@ public class AddressCountryLookupDescriptor implements LookupDescriptor, LookupD
 		{
 			throw new IllegalStateException("No ID provided in " + evalCtx);
 		}
-		
+
 		return getLookupValueById(id);
 	}
-	
+
 	public LookupValue getLookupValueById(final Object idObj)
 	{
 		final LookupValue country = getAllCountriesById().getById(idObj);
@@ -207,9 +208,13 @@ public class AddressCountryLookupDescriptor implements LookupDescriptor, LookupD
 	private IntegerLookupValue createLookupValue(final I_C_Country countryRecord)
 	{
 		final int countryId = countryRecord.getC_Country_ID();
-		final ITranslatableString countryName = InterfaceWrapperHelper.getModelTranslationMap(countryRecord)
-				.getColumnTrl(I_C_Country.COLUMNNAME_Name, countryRecord.getName());
-		return IntegerLookupValue.of(countryId, countryName);
+
+		final IModelTranslationMap modelTranslationMap = InterfaceWrapperHelper.getModelTranslationMap(countryRecord);
+
+		final ITranslatableString countryName = modelTranslationMap.getColumnTrl(I_C_Country.COLUMNNAME_Name, countryRecord.getName());
+		final ITranslatableString countryDescription = modelTranslationMap.getColumnTrl(I_C_Country.COLUMNNAME_Description, countryRecord.getName());
+
+		return IntegerLookupValue.of(countryId, countryName, countryDescription);
 	}
 
 	@Override

--- a/src/main/java/de/metas/ui/web/address/AddressPostalLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/address/AddressPostalLookupDescriptor.java
@@ -27,8 +27,8 @@ import de.metas.ui.web.window.descriptor.DocumentLayoutElementFieldDescriptor.Lo
 import de.metas.ui.web.window.descriptor.LookupDescriptor;
 import de.metas.ui.web.window.model.lookup.LookupDataSourceContext;
 import de.metas.ui.web.window.model.lookup.LookupDataSourceContext.Builder;
-import de.metas.util.Check;
 import de.metas.ui.web.window.model.lookup.LookupDataSourceFetcher;
+import de.metas.util.Check;
 import lombok.NonNull;
 
 /*
@@ -84,7 +84,7 @@ public class AddressPostalLookupDescriptor implements LookupDescriptor, LookupDa
 	{
 		return true; // not cached but returning true to avoid caching
 	}
-	
+
 	@Override
 	public void cacheInvalidate()
 	{
@@ -225,7 +225,7 @@ public class AddressPostalLookupDescriptor implements LookupDescriptor, LookupDa
 				final String postal = rs.getString(I_C_Postal.COLUMNNAME_Postal);
 				final String city = rs.getString(I_C_Postal.COLUMNNAME_City);
 				final int countryId = rs.getInt(I_C_Postal.COLUMNNAME_C_Country_ID);
-				
+
 				final LookupValue countryLookupValue = countryLookup.getLookupValueById(countryId);
 
 				lookupValues.add(buildPostalLookupValue(postalId, postal, city, countryLookupValue.getDisplayNameTrl()));
@@ -242,7 +242,7 @@ public class AddressPostalLookupDescriptor implements LookupDescriptor, LookupDa
 			DB.close(rs, pstmt);
 		}
 	}
-	
+
 	public IntegerLookupValue getLookupValueFromLocation(final I_C_Location locationRecord)
 	{
 		final I_C_Postal postalRecord = locationRecord.getC_Postal();
@@ -250,15 +250,19 @@ public class AddressPostalLookupDescriptor implements LookupDescriptor, LookupDa
 		{
 			return null;
 		}
-		
+
 		final LookupValue countryLookupValue = countryLookup.getLookupValueById(postalRecord.getC_Country_ID());
 
 		return buildPostalLookupValue(postalRecord.getC_Postal_ID(), postalRecord.getPostal(), postalRecord.getCity(), countryLookupValue.getDisplayNameTrl());
 	}
 
-	private static final IntegerLookupValue buildPostalLookupValue(final int postalId, final String postal, final String city, final ITranslatableString countryName)
+	private static final IntegerLookupValue buildPostalLookupValue(
+			final int postalId,
+			final String postal,
+			final String city,
+			final ITranslatableString countryName)
 	{
 		final ITranslatableString displayName = ITranslatableString.compose("", postal, " ", city, " (", countryName, ")");
-		return IntegerLookupValue.of(postalId, displayName);
+		return IntegerLookupValue.of(postalId, displayName, null/* description */);
 	}
 }

--- a/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
+++ b/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
@@ -373,7 +373,7 @@ public class BoardDescriptorRepository
 					.append("SELECT ")
 					.append("\n  a." + I_WEBUI_Board_RecordAssignment.COLUMNNAME_WEBUI_Board_Lane_ID)
 					.append("\n, a." + I_WEBUI_Board_RecordAssignment.COLUMNNAME_Record_ID)
-					.append("\n, (").append(documentLookup.getSqlForFetchingDisplayNameByIdExpression(keyColumnNameFQ)).append(") AS card$caption")
+					.append("\n, (").append(documentLookup.getSqlForFetchingLookupByIdExpression(keyColumnNameFQ)).append(") AS card$caption")
 					//
 					.append("\n, u." + I_AD_User.COLUMNNAME_AD_User_ID + " AS card$user_id")
 					.append("\n, u." + I_AD_User.COLUMNNAME_Avatar_ID + " AS card$user_avatar_id")
@@ -436,7 +436,7 @@ public class BoardDescriptorRepository
 					.append("SELECT ")
 					.append("\n  NULL AS " + I_WEBUI_Board_RecordAssignment.COLUMNNAME_WEBUI_Board_Lane_ID)
 					.append("\n, " + keyColumnNameFQ + " AS " + I_WEBUI_Board_RecordAssignment.COLUMNNAME_Record_ID)
-					.append("\n, (").append(documentLookup.getSqlForFetchingDisplayNameByIdExpression(keyColumnNameFQ)).append(") AS card$caption")
+					.append("\n, (").append(documentLookup.getSqlForFetchingLookupByIdExpression(keyColumnNameFQ)).append(") AS card$caption")
 					//
 					.append("\n, u." + I_AD_User.COLUMNNAME_AD_User_ID + " AS card$user_id")
 					.append("\n, u." + I_AD_User.COLUMNNAME_Avatar_ID + " AS card$user_avatar_id")

--- a/src/main/java/de/metas/ui/web/handlingunits/process/WebuiHUTransformParametersFiller.java
+++ b/src/main/java/de/metas/ui/web/handlingunits/process/WebuiHUTransformParametersFiller.java
@@ -179,9 +179,10 @@ public class WebuiHUTransformParametersFiller
 
 		final String adLanguage = Env.getAD_Language();
 
-		return allActiveActionItems.stream()
+		return allActiveActionItems
+				.stream()
 				.filter(item -> allowedActions.contains(item.getValueName()))
-				.map(item -> StringLookupValue.of(item.getValueName(), item.getName()))
+				.map(item -> StringLookupValue.of(item.getValueName(), item.getName(), item.getDescription()))
 				.sorted(Comparator.comparing(lookupValue -> lookupValue.getDisplayName(adLanguage)))
 				.collect(LookupValuesList.collect());
 	}

--- a/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
+++ b/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
@@ -12,6 +12,8 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.model.I_C_UOM;
+import org.compiere.util.Env;
+import org.compiere.util.KeyNamePair;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.metas.handlingunits.HUPIItemProductId;
@@ -28,7 +30,6 @@ import de.metas.handlingunits.picking.PickingCandidateService;
 import de.metas.handlingunits.picking.requests.AddQtyToHURequest;
 import de.metas.handlingunits.report.HUReportService;
 import de.metas.handlingunits.report.HUToReportWrapper;
-import de.metas.i18n.ITranslatableString;
 import de.metas.picking.api.PickingConfigRepository;
 import de.metas.picking.api.PickingSlotId;
 import de.metas.process.IProcessDefaultParameter;
@@ -57,12 +58,12 @@ import lombok.NonNull;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -70,10 +71,10 @@ import lombok.NonNull;
  */
 
 /**
- * 
+ *
  * Note: this process is declared in the {@code AD_Process} table, but <b>not</b> added to it's respective window or table via application dictionary.<br>
  * Instead it is assigned to it's place by {@link PickingSlotViewFactory}.
- * 
+ *
  * @author metas-dev <dev@metasfresh.com>
  *
  */
@@ -179,7 +180,7 @@ public class WEBUI_Picking_PickQtyToNewHU
 	}
 
 	/**
-	 * 
+	 *
 	 * @return a list of PI item products that match the selected shipment schedule's product and partner, sorted by name.
 	 */
 	@ProcessParamLookupValuesProvider(parameterName = PARAM_M_HU_PI_Item_Product_ID, dependsOn = {}, numericKey = true, lookupTableName = I_M_HU_PI_Item_Product.Table_Name)
@@ -212,8 +213,11 @@ public class WEBUI_Picking_PickQtyToNewHU
 			}
 			else
 			{
-				final ITranslatableString displayName = Services.get(IHUPIItemProductBL.class).getDisplayName(piItemProductId);
-				return IntegerLookupValue.of(piItemProductId, displayName);
+				final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
+				final String adLanguage = Env.getAD_Language();
+
+				final KeyNamePair keyNamePair = hupiItemProductBL.getDisplayName(piItemProductId, adLanguage);
+				return IntegerLookupValue.fromNamePair(keyNamePair, adLanguage);
 			}
 		}
 		else
@@ -239,7 +243,7 @@ public class WEBUI_Picking_PickQtyToNewHU
 
 	/**
 	 * Creates a new M_HU within the processe's interited trx.
-	 * 
+	 *
 	 * @param itemProduct
 	 * @param locatorId
 	 * @return

--- a/src/main/java/de/metas/ui/web/view/SqlViewDataRepository.java
+++ b/src/main/java/de/metas/ui/web/view/SqlViewDataRepository.java
@@ -254,7 +254,8 @@ class SqlViewDataRepository implements IViewDataRepository
 		}
 	}
 
-	private final ImmutableList<IViewRow> loadViewRows(final ResultSet rs,
+	private final ImmutableList<IViewRow> loadViewRows(
+			@NonNull final ResultSet rs,
 			final ViewEvaluationCtx viewEvalCtx,
 			final ViewId viewId,
 			final int limit) throws SQLException
@@ -307,7 +308,10 @@ class SqlViewDataRepository implements IViewDataRepository
 				.collect(ImmutableList.toImmutableList());
 	}
 
-	private ViewRow.Builder loadViewRow(final ResultSet rs, final WindowId windowId, final String adLanguage) throws SQLException
+	private ViewRow.Builder loadViewRow(
+			@NonNull final ResultSet rs,
+			final WindowId windowId,
+			final String adLanguage) throws SQLException
 	{
 		final boolean isRecordMissing = DisplayType.toBoolean(rs.getString(SqlViewSelectData.COLUMNNAME_IsRecordMissing));
 		if (isRecordMissing)

--- a/src/main/java/de/metas/ui/web/view/SqlViewFactory.java
+++ b/src/main/java/de/metas/ui/web/view/SqlViewFactory.java
@@ -493,7 +493,7 @@ public class SqlViewFactory implements IViewFactory
 		private final boolean isDisplayColumnAvailable;
 
 		@Override
-		public Object retrieveValueAsJson(final ResultSet rs, final String adLanguage) throws SQLException
+		public Object retrieveValueAsJson(@NonNull final ResultSet rs, final String adLanguage) throws SQLException
 		{
 			final Object fieldValue = fieldValueLoader.retrieveFieldValue(rs, isDisplayColumnAvailable, adLanguage, (LookupDescriptor)null);
 			return Values.valueToJsonObject(fieldValue);

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONLookupValue.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONLookupValue.java
@@ -99,7 +99,7 @@ public final class JSONLookupValue
 	}
 
 	public static final IntegerLookupValue integerLookupValueFromJsonMap(
-			final Map<String, Object> map)
+			@NonNull final Map<String, Object> map)
 	{
 		final Object keyObj = map.get(PROPERTY_Key);
 		if (keyObj == null)
@@ -113,13 +113,8 @@ public final class JSONLookupValue
 		}
 		final int keyInt = Integer.parseInt(keyStr);
 
-		final Object captionObj = map.get(PROPERTY_Caption);
-		final String caption = captionObj != null ? captionObj.toString() : "";
-		final ITranslatableString displayName = ImmutableTranslatableString.anyLanguage(caption);
-
-		final Object descriptionObj = map.get(PROPERTY_Description);
-		final String descriptionStr = descriptionObj != null ? descriptionObj.toString() : "";
-		final ITranslatableString description = ImmutableTranslatableString.anyLanguage(descriptionStr);
+		final ITranslatableString displayName = extractCaption(map);
+		final ITranslatableString description = extractDescription(map);
 
 		final IntegerLookupValueBuilder builder = IntegerLookupValue.builder()
 				.id(keyInt)
@@ -141,13 +136,8 @@ public final class JSONLookupValue
 		final Object keyObj = map.get(PROPERTY_Key);
 		final String key = keyObj != null ? keyObj.toString() : null;
 
-		final Object captionObj = map.get(PROPERTY_Caption);
-		final String caption = captionObj != null ? captionObj.toString() : "";
-		final ITranslatableString displayName = ImmutableTranslatableString.anyLanguage(caption);
-
-		final Object descriptionObj = map.get(PROPERTY_Description);
-		final String descriptionStr = descriptionObj != null ? descriptionObj.toString() : "";
-		final ITranslatableString description = ImmutableTranslatableString.anyLanguage(descriptionStr);
+		final ITranslatableString displayName = extractCaption(map);
+		final ITranslatableString description = extractDescription(map);
 
 		final StringLookupValueBuilder builder = StringLookupValue.builder()
 				.id(key)
@@ -162,6 +152,22 @@ public final class JSONLookupValue
 		}
 
 		return builder.build();
+	}
+
+	private static ITranslatableString extractCaption(@NonNull final Map<String, Object> map)
+	{
+		final Object captionObj = map.get(PROPERTY_Caption);
+		final String caption = captionObj != null ? captionObj.toString() : "";
+		final ITranslatableString displayName = ImmutableTranslatableString.anyLanguage(caption);
+		return displayName;
+	}
+
+	private static ITranslatableString extractDescription(final Map<String, Object> map)
+	{
+		final Object descriptionObj = map.get(PROPERTY_Description);
+		final String descriptionStr = descriptionObj != null ? descriptionObj.toString() : "";
+		final ITranslatableString description = ImmutableTranslatableString.anyLanguage(descriptionStr);
+		return description;
 	}
 
 	public static JSONLookupValue unknown(final int id)

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONLookupValue.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONLookupValue.java
@@ -2,6 +2,8 @@ package de.metas.ui.web.window.datatypes.json;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.compiere.util.Env;
 import org.compiere.util.NamePair;
 
@@ -19,9 +21,12 @@ import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.ImmutableTranslatableString;
 import de.metas.ui.web.window.datatypes.LookupValue;
 import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
+import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue.IntegerLookupValueBuilder;
 import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue;
+import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue.StringLookupValueBuilder;
 import io.swagger.annotations.ApiModel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
 
 /*
@@ -51,16 +56,27 @@ import lombok.NonNull;
 @EqualsAndHashCode
 public final class JSONLookupValue
 {
-	public static final JSONLookupValue of(final String key, final String caption)
-	{
-		final Map<String, Object> attributes = null;
-		return new JSONLookupValue(key, caption, attributes);
-	}
 
 	public static final JSONLookupValue of(final int key, final String caption)
 	{
 		final String keyStr = String.valueOf(key);
-		return of(keyStr, caption);
+		return of(keyStr, caption, null/* description */);
+	}
+
+	public static final JSONLookupValue of(
+			final String key,
+			final String caption)
+	{
+		return of(key, caption, null/* description */);
+	}
+
+	public static final JSONLookupValue of(
+			final String key,
+			final String caption,
+			@Nullable final String description)
+	{
+		final Map<String, Object> attributes = null;
+		return new JSONLookupValue(key, caption, description, attributes);
 	}
 
 	public static final JSONLookupValue ofLookupValue(final LookupValue lookupValue)
@@ -68,18 +84,22 @@ public final class JSONLookupValue
 		final String id = lookupValue.getIdAsString();
 
 		final ITranslatableString displayNameTrl = lookupValue.getDisplayNameTrl();
+		final ITranslatableString descriptionTrl = lookupValue.getDescriptionTrl();
+
 		final String adLanguage = Env.getAD_Language(Env.getCtx()); // FIXME add it as parameter!
 		final String displayName = displayNameTrl.translate(adLanguage);
+		final String description = descriptionTrl.translate(adLanguage);
 
-		return new JSONLookupValue(id, displayName, lookupValue.getAttributes());
+		return new JSONLookupValue(id, displayName, description, lookupValue.getAttributes());
 	}
 
 	public static final JSONLookupValue ofNamePair(final NamePair namePair)
 	{
-		return of(namePair.getID(), namePair.getName());
+		return of(namePair.getID(), namePair.getName(), namePair.getDescription());
 	}
 
-	public static final IntegerLookupValue integerLookupValueFromJsonMap(final Map<String, Object> map)
+	public static final IntegerLookupValue integerLookupValueFromJsonMap(
+			final Map<String, Object> map)
 	{
 		final Object keyObj = map.get(PROPERTY_Key);
 		if (keyObj == null)
@@ -97,18 +117,23 @@ public final class JSONLookupValue
 		final String caption = captionObj != null ? captionObj.toString() : "";
 		final ITranslatableString displayName = ImmutableTranslatableString.anyLanguage(caption);
 
-		@SuppressWarnings("unchecked")
-		final Map<String, Object> attributes = (Map<String, Object>)map.get(PROPERTY_Attributes);
-		if (attributes == null || attributes.isEmpty())
-		{
-			return IntegerLookupValue.of(keyInt, displayName);
-		}
+		final Object descriptionObj = map.get(PROPERTY_Description);
+		final String descriptionStr = descriptionObj != null ? descriptionObj.toString() : "";
+		final ITranslatableString description = ImmutableTranslatableString.anyLanguage(descriptionStr);
 
-		return IntegerLookupValue.builder()
+		final IntegerLookupValueBuilder builder = IntegerLookupValue.builder()
 				.id(keyInt)
 				.displayName(displayName)
-				.attributes(attributes)
-				.build();
+				.description(description);
+
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> attributes = (Map<String, Object>)map.get(PROPERTY_Attributes);
+		if (attributes != null && !attributes.isEmpty())
+		{
+			builder.attributes(attributes);
+		}
+
+		return builder.build();
 	}
 
 	public static final StringLookupValue stringLookupValueFromJsonMap(final Map<String, Object> map)
@@ -120,18 +145,23 @@ public final class JSONLookupValue
 		final String caption = captionObj != null ? captionObj.toString() : "";
 		final ITranslatableString displayName = ImmutableTranslatableString.anyLanguage(caption);
 
-		@SuppressWarnings("unchecked")
-		final Map<String, Object> attributes = (Map<String, Object>)map.get(PROPERTY_Attributes);
-		if (attributes == null || attributes.isEmpty())
-		{
-			return StringLookupValue.of(key, displayName);
-		}
+		final Object descriptionObj = map.get(PROPERTY_Description);
+		final String descriptionStr = descriptionObj != null ? descriptionObj.toString() : "";
+		final ITranslatableString description = ImmutableTranslatableString.anyLanguage(descriptionStr);
 
-		return StringLookupValue.builder()
+		final StringLookupValueBuilder builder = StringLookupValue.builder()
 				.id(key)
 				.displayName(displayName)
-				.attributes(attributes)
-				.build();
+				.description(description);
+
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> attributes = (Map<String, Object>)map.get(PROPERTY_Attributes);
+		if (attributes != null && !attributes.isEmpty())
+		{
+			builder.attributes(attributes);
+		}
+
+		return builder.build();
 	}
 
 	public static JSONLookupValue unknown(final int id)
@@ -152,34 +182,47 @@ public final class JSONLookupValue
 
 		final String key = Joiner.on("_").skipNulls().join(lookupValue1.getKey(), lookupValue2.getKey());
 		final String caption = Joiner.on(" ").skipNulls().join(lookupValue1.getCaption(), lookupValue2.getCaption());
-		return JSONLookupValue.of(key, caption);
+		final String description = Joiner.on(" ").skipNulls().join(lookupValue1.getDescription(), lookupValue2.getDescription());
+		return JSONLookupValue.of(key, caption, description);
 
 	}
 
 	// IMPORTANT: when changing this property name, pls also check/change de.metas.handlingunits.attribute.impl.AbstractAttributeValue.extractKey(Map<String, String>, I_M_Attribute)
 	private static final String PROPERTY_Key = "key";
 	@JsonProperty(PROPERTY_Key)
+	@Getter
 	private final String key;
+
 	@JsonIgnore
 	private transient Integer keyAsInt = null; // lazy
 
 	private static final String PROPERTY_Caption = "caption";
 	@JsonProperty(PROPERTY_Caption)
+	@Getter
 	private final String caption;
+
+	private static final String PROPERTY_Description = "description";
+	@JsonProperty(PROPERTY_Description)
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@Getter
+	private final String description;
 
 	private static final String PROPERTY_Attributes = "attributes";
 	@JsonProperty(PROPERTY_Attributes)
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@Getter
 	private final Map<String, Object> attributes;
 
 	@JsonCreator
 	private JSONLookupValue(
 			@JsonProperty(PROPERTY_Key) @NonNull final String key,
 			@JsonProperty(PROPERTY_Caption) @NonNull final String caption,
+			@JsonProperty(PROPERTY_Description) @Nullable final String description,
 			@JsonProperty(PROPERTY_Attributes) final Map<String, Object> attributes)
 	{
 		this.key = key;
 		this.caption = caption;
+		this.description = description;
 		this.attributes = attributes != null && !attributes.isEmpty() ? ImmutableMap.copyOf(attributes) : ImmutableMap.of();
 	}
 
@@ -193,11 +236,6 @@ public final class JSONLookupValue
 				.toString();
 	}
 
-	public String getKey()
-	{
-		return key;
-	}
-
 	public int getKeyAsInt()
 	{
 		if (keyAsInt == null)
@@ -206,16 +244,6 @@ public final class JSONLookupValue
 		}
 
 		return keyAsInt;
-	}
-
-	public String getCaption()
-	{
-		return caption;
-	}
-
-	public Map<String, Object> getAttributes()
-	{
-		return attributes;
 	}
 
 	public LookupValue toIntegerLookupValue()

--- a/src/main/java/de/metas/ui/web/window/descriptor/FullTextSearchLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/FullTextSearchLookupDescriptor.java
@@ -234,8 +234,8 @@ public class FullTextSearchLookupDescriptor implements ISqlLookupDescriptor, Loo
 	}
 
 	@Override
-	public IStringExpression getSqlForFetchingDisplayNameByIdExpression(final String sqlKeyColumn)
+	public IStringExpression getSqlForFetchingLookupByIdExpression(final String sqlKeyColumn)
 	{
-		return sqlLookupDescriptor != null ? sqlLookupDescriptor.getSqlForFetchingDisplayNameByIdExpression(sqlKeyColumn) : NullStringExpression.instance;
+		return sqlLookupDescriptor != null ? sqlLookupDescriptor.getSqlForFetchingLookupByIdExpression(sqlKeyColumn) : NullStringExpression.instance;
 	}
 }

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/ISqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/ISqlLookupDescriptor.java
@@ -28,5 +28,5 @@ import de.metas.ui.web.window.descriptor.LookupDescriptor;
 
 public interface ISqlLookupDescriptor extends LookupDescriptor
 {
-	IStringExpression getSqlForFetchingDisplayNameByIdExpression(String sqlKeyColumn);
+	IStringExpression getSqlForFetchingLookupByIdExpression(String sqlKeyColumn);
 }

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDocumentFieldDataBindingDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDocumentFieldDataBindingDescriptor.java
@@ -122,7 +122,6 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 		sqlSelectValue = builder.buildSqlSelectValue();
 		sqlSelectDisplayValue = builder.buildSqlSelectDisplayValue();
 
-		//
 		// ORDER BY
 		{
 			defaultOrderByPriority = builder.orderByPriority;
@@ -289,13 +288,14 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 		// Built values
 		private boolean _usingDisplayColumn;
 		private String _displayColumnName;
+		//private String _descriptionColumnName;
+
 		private IStringExpression _displayColumnSqlExpression;
 		private Boolean _numericKey;
 		private DocumentFieldValueLoader _documentFieldValueLoader;
 
 		private Builder()
 		{
-			super();
 		}
 
 		public SqlDocumentFieldDataBindingDescriptor build()
@@ -342,7 +342,7 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 			}
 
 			final String sqlColumnNameFQ = sqlTableAlias + "." + sqlColumnName;
-			final IStringExpression displayColumnSqlExpression = sqlLookupDescriptor.getSqlForFetchingDisplayNameByIdExpression(sqlColumnNameFQ);
+			final IStringExpression displayColumnSqlExpression = sqlLookupDescriptor.getSqlForFetchingLookupByIdExpression(sqlColumnNameFQ);
 			if (displayColumnSqlExpression == null || displayColumnSqlExpression.isNullExpression())
 			{
 				return ConstantStringExpression.of(sqlColumnName);
@@ -398,7 +398,8 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 			{
 				_documentFieldValueLoader = createDocumentFieldValueLoader(
 						getColumnName(),
-						isUsingDisplayColumn() ? getDisplayColumnName() : null, // displayColumnName
+						isUsingDisplayColumn() ? getDisplayColumnName() : null/* displayColumnName */,
+//						isUsingDisplayColumn() ? getDescriptionColumnName() : null/* descriptionColumnName */,
 						getValueClass(),
 						getWidgetType(),
 						encrypted,
@@ -408,30 +409,26 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 		}
 
 		/**
-		 *
 		 * NOTE to developer: make sure there is NO reference to fieldDescriptor or dataBinding or anything else in returned lambdas.
 		 * They shall be independent from descriptors.
 		 * That's the reason why it's a static method (to make sure we are no doing any mistakes).
 		 *
-		 * @param sqlColumnName
-		 * @param displayColumnName
-		 * @param valueClass
-		 * @param encrypted
-		 * @param numericKey
+		 * @param descriptionColumnName currently only used in lookup value
+		 *
 		 * @return document field value loader
 		 */
 		private static final DocumentFieldValueLoader createDocumentFieldValueLoader(
-				final String sqlColumnName //
-				, final String displayColumnName //
-				, final Class<?> valueClass //
-				, final DocumentFieldWidgetType widgetType //
-				, final boolean encrypted //
-				, final Boolean numericKey //
-		)
+				final String sqlColumnName,
+				final String displayColumnName,
+				//final String descriptionColumnName,
+				final Class<?> valueClass,
+				final DocumentFieldWidgetType widgetType,
+				final boolean encrypted,
+				final Boolean numericKey)
 		{
 			if (!Check.isEmpty(displayColumnName))
 			{
-				return DocumentFieldValueLoaders.toLookupValue(sqlColumnName, displayColumnName, numericKey);
+				return DocumentFieldValueLoaders.toLookupValue(sqlColumnName, displayColumnName, /*descriptionColumnName,*/ numericKey);
 			}
 			else if (java.lang.String.class == valueClass)
 			{
@@ -621,6 +618,11 @@ public class SqlDocumentFieldDataBindingDescriptor implements DocumentFieldDataB
 		{
 			return _displayColumnName;
 		}
+
+//		private String getDescriptionColumnName()
+//		{
+//			return _descriptionColumnName;
+//		}
 
 		public IStringExpression getDisplayColumnSqlExpression()
 		{


### PR DESCRIPTION
* add description to LookupValue, JSONLookupValue etc
* GenericSqlLookupDataSourceFetcher - use the new method in DB to fetch both name and description at once
* SqlLookupDescriptor - create the "..$Display" subselects such that they select an array. That way *one* subselect can return both the displayName *and* description
  * See https://dba.stackexchange.com/questions/15976/get-multiple-columns-from-a-select-subquery/226343#226343
* DocumentFieldValueLoaders - handle the case that "...$Display" columns can contain either just a string (displayName) or an array of strings (name and description)

https://github.com/metasfresh/metasfresh/issues/4798