### PR TITLE
1128-api - Limit number of products shown in material cockpit

### DIFF
--- a/src/main/java/de/metas/ui/web/document/filter/DocumentFilter.java
+++ b/src/main/java/de/metas/ui/web/document/filter/DocumentFilter.java
@@ -331,6 +331,5 @@ public final class DocumentFilter
 			}
 			internalParameterNames.add(parameterName);
 		}
-
 	}
 }

--- a/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowRepository.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowRepository.java
@@ -64,8 +64,10 @@ import lombok.Value;
 public class MaterialCockpitRowRepository
 {
 	private static final String SYSCONFIG_EMPTY_PRODUCTS_LIMIT = "de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.Limit";
+	private static final int DEFAULT_EMPTY_PRODUCTS_LIMIT = 2000;
 
 	private static final String SYSCONFIG_EMPTY_PRODUCTS_CACHESIZE = "de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.CacheSize";
+	private static final int DEFAULT_EMPTY_PRODUCTS_CACHESIZE = 10;
 
 	private final transient CCache<CacheKey, List<I_M_Product>> productFilterVOToProducts;
 
@@ -91,7 +93,7 @@ public class MaterialCockpitRowRepository
 		// setup caching
 		final int cacheSize = Services
 				.get(ISysConfigBL.class)
-				.getIntValue(SYSCONFIG_EMPTY_PRODUCTS_CACHESIZE, 10);
+				.getIntValue(SYSCONFIG_EMPTY_PRODUCTS_CACHESIZE, DEFAULT_EMPTY_PRODUCTS_CACHESIZE);
 
 		productFilterVOToProducts = CCache
 				.<CacheKey, List<I_M_Product>> builder()
@@ -181,7 +183,9 @@ public class MaterialCockpitRowRepository
 	{
 		final OrgId orgId = OrgId.ofRepoIdOrAny(Env.getAD_Org_ID(Env.getCtx()));
 
-		final int limit = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_EMPTY_PRODUCTS_LIMIT, 2000);
+		final int limit = Services
+				.get(ISysConfigBL.class)
+				.getIntValue(SYSCONFIG_EMPTY_PRODUCTS_LIMIT, DEFAULT_EMPTY_PRODUCTS_LIMIT);
 
 		final CacheKey cacheKey = new CacheKey(
 				orgId,

--- a/src/main/java/de/metas/ui/web/material/cockpit/filters/MaterialCockpitFilters.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/filters/MaterialCockpitFilters.java
@@ -168,4 +168,5 @@ public class MaterialCockpitFilters
 		return ProductFilterUtil.toPredicate(filters);
 	}
 
+
 }

--- a/src/main/java/de/metas/ui/web/material/cockpit/filters/ProductFilterVO.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/filters/ProductFilterVO.java
@@ -16,12 +16,12 @@ import lombok.Value;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -30,7 +30,7 @@ import lombok.Value;
 
 @Value
 @Builder
-class ProductFilterVO
+public class ProductFilterVO
 {
 	public static final ProductFilterVO EMPTY = builder().build();
 

--- a/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/CountingSubRowBucket.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/CountingSubRowBucket.java
@@ -1,6 +1,7 @@
 package de.metas.ui.web.material.cockpit.rowfactory;
 
 import static de.metas.quantity.Quantity.addToNullable;
+import static de.metas.util.Check.assumeNotNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -86,11 +87,13 @@ public class CountingSubRowBucket
 
 	public MaterialCockpitRow createIncludedRow(@NonNull final MainRowWithSubRows mainRowBucket)
 	{
-		final MainRowBucketId productIdAndDate = mainRowBucket.getProductIdAndDate();
+		final MainRowBucketId productIdAndDate = assumeNotNull(
+				mainRowBucket.getProductIdAndDate(),
+				"productIdAndDate may not be null; mainRowBucket={}", mainRowBucket);
 
 		return MaterialCockpitRow.countingSubRowBuilder()
 				.date(productIdAndDate.getDate())
-				.productId(productIdAndDate.getProductId())
+				.productId(productIdAndDate.getProductId().getRepoId())
 				.plantId(plantId)
 				.qtyOnHandEstimate(qtyOnHandEstimate)
 				.qtyOnHandStock(qtyOnHandStock)

--- a/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/DimensionGroupSubRowBucket.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/DimensionGroupSubRowBucket.java
@@ -1,6 +1,7 @@
 package de.metas.ui.web.material.cockpit.rowfactory;
 
 import static de.metas.quantity.Quantity.addToNullable;
+import static de.metas.util.Check.assumeNotNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -104,11 +105,13 @@ public class DimensionGroupSubRowBucket
 
 	public MaterialCockpitRow createIncludedRow(@NonNull final MainRowWithSubRows mainRowBucket)
 	{
-		final MainRowBucketId productIdAndDate = mainRowBucket.getProductIdAndDate();
+		final MainRowBucketId productIdAndDate = assumeNotNull(
+				mainRowBucket.getProductIdAndDate(),
+				"productIdAndDate may not be null; mainRowBucket={}", mainRowBucket);
 
 		return MaterialCockpitRow.attributeSubRowBuilder()
 				.date(productIdAndDate.getDate())
-				.productId(productIdAndDate.getProductId())
+				.productId(productIdAndDate.getProductId().getRepoId())
 
 				.dimensionGroup(dimensionSpecGroup)
 				.pmmQtyPromised(getPmmQtyPromised())

--- a/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/MainRowBucketId.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/MainRowBucketId.java
@@ -7,6 +7,7 @@ import org.compiere.util.TimeUtil;
 
 import de.metas.material.cockpit.model.I_MD_Cockpit;
 import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.product.ProductId;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -39,7 +40,7 @@ public class MainRowBucketId
 			@NonNull final I_MD_Cockpit dataRecord)
 	{
 		return new MainRowBucketId(
-				dataRecord.getM_Product_ID(),
+				ProductId.ofRepoId(dataRecord.getM_Product_ID()),
 				TimeUtil.getDay(dataRecord.getDateGeneral()));
 	}
 
@@ -48,16 +49,16 @@ public class MainRowBucketId
 			@NonNull final Timestamp date)
 	{
 		return new MainRowBucketId(
-				stockRecord.getM_Product_ID(),
+				ProductId.ofRepoId(stockRecord.getM_Product_ID()),
 				TimeUtil.getDay(date));
 	}
 
-	public static MainRowBucketId createPlainInstance(final int productId, @NonNull final Timestamp date)
+	public static MainRowBucketId createPlainInstance(@NonNull final ProductId productId, @NonNull final Timestamp date)
 	{
 		return new MainRowBucketId(productId, date);
 	}
 
-	int productId;
+	ProductId productId;
 	Timestamp date;
 
 	private BigDecimal pmmQtyPromised = BigDecimal.ZERO;
@@ -74,7 +75,9 @@ public class MainRowBucketId
 
 	private BigDecimal qtyOnHand = BigDecimal.ZERO;
 
-	private MainRowBucketId(final int productId, @NonNull final Timestamp date)
+	private MainRowBucketId(
+			@NonNull final ProductId productId,
+			@NonNull final Timestamp date)
 	{
 		this.productId = productId;
 		this.date = date;

--- a/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactory.java
+++ b/src/main/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactory.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.adempiere.ad.dao.IQueryBL;
-import org.compiere.model.I_M_Product;
 import org.compiere.model.I_S_Resource;
 import org.compiere.model.X_S_Resource;
 import org.springframework.stereotype.Service;
@@ -15,11 +14,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableSet;
 
 import de.metas.dimension.DimensionSpec;
 import de.metas.dimension.DimensionSpecGroup;
 import de.metas.material.cockpit.model.I_MD_Cockpit;
 import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.product.ProductId;
 import de.metas.ui.web.material.cockpit.MaterialCockpitRow;
 import de.metas.ui.web.material.cockpit.MaterialCockpitUtil;
 import de.metas.util.Services;
@@ -59,7 +60,7 @@ public class MaterialCockpitRowFactory
 		Timestamp date;
 
 		@NonNull
-		List<I_M_Product> productsToListEvenIfEmpty;
+		ImmutableSet<ProductId> productIdsToListEvenIfEmpty;
 
 		@NonNull
 		List<I_MD_Cockpit> cockpitRecords;
@@ -73,7 +74,7 @@ public class MaterialCockpitRowFactory
 	public List<MaterialCockpitRow> createRows(@NonNull final CreateRowsRequest request)
 	{
 		final Map<MainRowBucketId, MainRowWithSubRows> emptyRowBuckets = createEmptyRowBuckets(
-				request.getProductsToListEvenIfEmpty(),
+				request.getProductIdsToListEvenIfEmpty(),
 				request.getDate(),
 				request.isIncludePerPlantDetailRows());
 
@@ -92,7 +93,7 @@ public class MaterialCockpitRowFactory
 
 	@VisibleForTesting
 	Map<MainRowBucketId, MainRowWithSubRows> createEmptyRowBuckets(
-			@NonNull final List<I_M_Product> products,
+			@NonNull final ImmutableSet<ProductId> productIds,
 			@NonNull final Timestamp timestamp,
 			final boolean includePerPlantDetailRows)
 	{
@@ -102,9 +103,9 @@ public class MaterialCockpitRowFactory
 		final List<I_S_Resource> plants = retrieveCountingPlants(includePerPlantDetailRows);
 
 		final Builder<MainRowBucketId, MainRowWithSubRows> result = ImmutableMap.builder();
-		for (final I_M_Product product : products)
+		for (final ProductId productId : productIds)
 		{
-			final MainRowBucketId key = MainRowBucketId.createPlainInstance(product.getM_Product_ID(), timestamp);
+			final MainRowBucketId key = MainRowBucketId.createPlainInstance(productId, timestamp);
 			final MainRowWithSubRows mainRowBucket = MainRowWithSubRows.create(key);
 
 			for (final I_S_Resource plant : plants)

--- a/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -23,6 +23,7 @@ import org.adempiere.model.CopyRecordSupport;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.model.PlainContextAware;
 import org.adempiere.model.RecordZoomWindowFinder;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.PO;
@@ -95,6 +96,9 @@ import lombok.Value;
 @Component
 public class DocumentCollection
 {
+	private static final String SYSCONFIG_CACHE_SIZE = "de.metas.ui.web.window.model.DocumentCollection.CacheSize";
+	private static final int DEFAULT_CACHE_SIZE = 800;
+
 	private static final Logger logger = LogManager.getLogger(DocumentCollection.class);
 
 	@Autowired
@@ -106,12 +110,21 @@ public class DocumentCollection
 	@Autowired
 	private DocumentWebsocketPublisher websocketPublisher;
 
-	private final Cache<DocumentKey, Document> rootDocuments = CacheBuilder.newBuilder().build();
+	private final Cache<DocumentKey, Document> rootDocuments;
 
 	private final ConcurrentHashMap<String, Set<WindowId>> tableName2windowIds = new ConcurrentHashMap<>();
 
 	/* package */ DocumentCollection()
 	{
+		// setup the cache
+		final int cacheSize = Services
+				.get(ISysConfigBL.class)
+				.getIntValue(SYSCONFIG_CACHE_SIZE, 300);
+
+		rootDocuments = CacheBuilder
+				.newBuilder()
+				.maximumSize(cacheSize)
+				.build();
 	}
 
 	public DocumentDescriptorFactory getDocumentDescriptorFactory()

--- a/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -119,7 +119,7 @@ public class DocumentCollection
 		// setup the cache
 		final int cacheSize = Services
 				.get(ISysConfigBL.class)
-				.getIntValue(SYSCONFIG_CACHE_SIZE, 300);
+				.getIntValue(SYSCONFIG_CACHE_SIZE, DEFAULT_CACHE_SIZE);
 
 		rootDocuments = CacheBuilder
 				.newBuilder()

--- a/src/test/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactoryTest.java
+++ b/src/test/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import de.metas.dimension.DimensionSpec;
 import de.metas.dimension.DimensionSpecGroup;
@@ -43,6 +44,7 @@ import de.metas.handlingunits.model.I_M_Warehouse;
 import de.metas.material.cockpit.model.I_MD_Cockpit;
 import de.metas.material.cockpit.model.I_MD_Stock;
 import de.metas.material.event.commons.AttributesKey;
+import de.metas.product.ProductId;
 import de.metas.ui.web.material.cockpit.MaterialCockpitRow;
 import de.metas.ui.web.material.cockpit.MaterialCockpitUtil;
 import de.metas.ui.web.material.cockpit.rowfactory.MaterialCockpitRowFactory.CreateRowsRequest;
@@ -238,7 +240,7 @@ public class MaterialCockpitRowFactoryTest
 
 		final CreateRowsRequest request = CreateRowsRequest.builder()
 				.date(today)
-				.productsToListEvenIfEmpty(ImmutableList.of())
+				.productIdsToListEvenIfEmpty(ImmutableSet.of())
 				.cockpitRecords(ImmutableList.of(cockpitRecordWithAttributes, cockpitRecordWithEmptyAttributesKey))
 				.stockRecords(ImmutableList.of(stockRecordWithAttributes, stockRecordWithEmptyAttributesKey))
 				.includePerPlantDetailRows(true) // without this, we would not get 4 but 3 included rows
@@ -317,15 +319,16 @@ public class MaterialCockpitRowFactoryTest
 	public void createEmptyRowBuckets()
 	{
 		final Timestamp today = TimeUtil.getDay(SystemTime.asTimestamp());
+		final ProductId productId = ProductId.ofRepoId(product.getM_Product_ID());
 
 		// invoke method under test
 		final Map<MainRowBucketId, MainRowWithSubRows> result = materialCockpitRowFactory.createEmptyRowBuckets(
-				ImmutableList.of(product),
+				ImmutableSet.of(productId),
 				today,
 				true);
 
 		assertThat(result).hasSize(1);
-		final MainRowBucketId productIdAndDate = MainRowBucketId.createPlainInstance(product.getM_Product_ID(), today);
+		final MainRowBucketId productIdAndDate = MainRowBucketId.createPlainInstance(productId, today);
 		assertThat(result).containsKey(productIdAndDate);
 		final MainRowWithSubRows mainRowBucket = result.get(productIdAndDate);
 		assertThat(mainRowBucket.getProductIdAndDate()).isEqualTo(productIdAndDate);


### PR DESCRIPTION
* change the product cache for "empty" products to be merged into the cockpit lines from "all" products to ProductFilterVO based LRU caching
* also use the limit sysconfig value

https://github.com/metasfresh/metasfresh-webui-api/issues/1128