### PR TITLE
4959-app - data entry implementation

### DIFF
--- a/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
+++ b/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
@@ -234,8 +234,7 @@ public class DataEntryTabLoader
 				.map(Collection::size)
 				.max(Comparator.naturalOrder()).orElse(0);
 
-		ImmutableList.Builder<DocumentLayoutElementGroupDescriptor.Builder> elementGroups = ImmutableList.builder();
-
+		final ImmutableList.Builder<DocumentLayoutElementGroupDescriptor.Builder> elementGroups = ImmutableList.builder();
 
 		final List<DataEntryLine> dataEntryLines = dataEntrySection.getDataEntryLines();
 		for (final DataEntryLine dataEntryLine : dataEntryLines)

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementGroup.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementGroup.java
@@ -50,6 +50,7 @@ public final class JSONDocumentLayoutElementGroup implements Serializable
 	{
 		return elementGroups.stream()
 				.map(elementGroup -> of(elementGroup, jsonOpts))
+				.filter(group -> !group.isEmpty())
 				.collect(GuavaCollectors.toImmutableList());
 	}
 
@@ -125,5 +126,13 @@ public final class JSONDocumentLayoutElementGroup implements Serializable
 				.add("columnCount", columnCount)
 				.add("elements", elementLines.isEmpty() ? null : elementLines)
 				.toString();
+	}
+
+	private boolean isEmpty()
+	{
+		final boolean atLeastOneLineIsFilled = elementLines
+				.stream()
+				.anyMatch(line -> !line.isEmpty());
+		return !atLeastOneLineIsFilled;
 	}
 }

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementLine.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementLine.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -94,6 +95,7 @@ public class JSONDocumentLayoutElementLine implements Serializable
 		return elements;
 	}
 
+	@JsonIgnore
 	public boolean isEmpty()
 	{
 		return elements.isEmpty();

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementLine.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElementLine.java
@@ -3,6 +3,8 @@ package de.metas.ui.web.window.datatypes.json;
 import java.io.Serializable;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,11 +29,11 @@ import lombok.NonNull;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -69,15 +71,13 @@ public class JSONDocumentLayoutElementLine implements Serializable
 	}
 
 	@JsonCreator
-	private JSONDocumentLayoutElementLine(@JsonProperty("elements") final List<JSONDocumentLayoutElement> elements)
+	private JSONDocumentLayoutElementLine(@Nullable @JsonProperty("elements") final List<JSONDocumentLayoutElement> elements)
 	{
-		super();
 		this.elements = elements == null ? ImmutableList.of() : ImmutableList.copyOf(elements);
 	}
 
 	private JSONDocumentLayoutElementLine(final JSONDocumentLayoutElement element)
 	{
-		super();
 		elements = ImmutableList.of(element);
 	}
 
@@ -92,5 +92,10 @@ public class JSONDocumentLayoutElementLine implements Serializable
 	public List<JSONDocumentLayoutElement> getElements()
 	{
 		return elements;
+	}
+
+	public boolean isEmpty()
+	{
+		return elements.isEmpty();
 	}
 }


### PR DESCRIPTION
* JSONDocumentLayout* - don't return element groups where *all* elementLines are empty (otherwise the adv-section is shown as an empty rectangle)
* DataEntryTabLoader - minor
https://github.com/metasfresh/metasfresh/issues/4959