### PR TITLE
Revert "Gh5382"

### DIFF
--- a/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderScheduler.java
+++ b/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderScheduler.java
@@ -11,7 +11,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ScheduledFuture;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.model.RecordZoomWindowFinder;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_BPartner;
@@ -264,8 +263,8 @@ public class PurchaseCandidateReminderScheduler implements InitializingBean
 
 	private WindowId getWindowId(final String tableName)
 	{
-		final AdWindowId adWindowId = RecordZoomWindowFinder.findAdWindowId(tableName).get();
-		return WindowId.of(adWindowId);
+		final int windowIdInt = RecordZoomWindowFinder.findAD_Window_ID(tableName);
+		return WindowId.of(windowIdInt);
 	}
 
 	private static class RemindersQueue

--- a/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderSchedulerRestController.java
+++ b/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderSchedulerRestController.java
@@ -3,7 +3,6 @@ package de.metas.purchasecandidate.reminder;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.RecordZoomWindowFinder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +59,7 @@ public class PurchaseCandidateReminderSchedulerRestController
 	{
 		userSession.assertLoggedIn();
 
-		final AdWindowId purchaseCandidatesWindowId = RecordZoomWindowFinder.findAdWindowId(I_C_PurchaseCandidate.Table_Name).get();
+		final int purchaseCandidatesWindowId = RecordZoomWindowFinder.findAD_Window_ID(I_C_PurchaseCandidate.Table_Name);
 		if (!userSession.getUserRolePermissions().checkWindowPermission(purchaseCandidatesWindowId).hasWriteAccess())
 		{
 			throw new AdempiereException("No read/write access to purchase candidates window");

--- a/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
+++ b/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.api.impl.CompositeStringExpression;
@@ -177,10 +176,10 @@ public class BoardDescriptorRepository
 
 		//
 		// Board document info
-		AdWindowId adWindowId = null; // TODO boardPO.getAD_Window_ID();
-		if (adWindowId == null)
+		int adWindowId = 0; // TODO boardPO.getAD_Window_ID();
+		if (adWindowId <= 0)
 		{
-			adWindowId = RecordZoomWindowFinder.findAdWindowId(tableName).get();
+			adWindowId = RecordZoomWindowFinder.findAD_Window_ID(tableName);
 		}
 		final WindowId documentWindowId = WindowId.of(adWindowId);
 

--- a/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
+++ b/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
@@ -25,6 +25,7 @@ import de.metas.dataentry.layout.DataEntryTab.DocumentLinkColumnName;
 import de.metas.dataentry.model.I_DataEntry_SubTab;
 import de.metas.dataentry.model.I_DataEntry_Tab;
 import de.metas.i18n.TranslatableStrings;
+import de.metas.ui.web.window.datatypes.DocumentType;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.ui.web.window.descriptor.DetailId;
 import de.metas.ui.web.window.descriptor.DocumentEntityDescriptor;
@@ -324,7 +325,7 @@ public class DataEntryTabLoader
 
 		final DocumentEntityDescriptor documentEntityDescriptor = DocumentEntityDescriptor
 				.builder()
-				.setDocumentType(getAdWindowId())
+				.setDocumentType(DocumentType.Window, getAdWindowId().getRepoId())
 				.setDetailId(createDetailIdFor(dataEntryTab))
 				.setInternalName(dataEntryTab.getInternalName())
 				.setCaption(dataEntryTab.getCaption())
@@ -353,7 +354,7 @@ public class DataEntryTabLoader
 		final DocumentEntityDescriptor.Builder documentEntityDescriptor = DocumentEntityDescriptor
 				.builder()
 				.setSingleRowDetail(true)
-				.setDocumentType(getAdWindowId())
+				.setDocumentType(DocumentType.Window, getAdWindowId().getRepoId())
 				.setDetailId(createDetailIdFor(dataEntrySubTab))
 				.setInternalName(dataEntrySubTab.getInternalName())
 				.setCaption(dataEntrySubTab.getCaption())

--- a/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
+++ b/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
@@ -160,7 +160,7 @@ public abstract class HUEditorViewFactoryTemplate implements IViewFactory
 			sqlWhereClause.append(I_M_HU.COLUMNNAME_M_HU_Item_Parent_ID + " is null"); // top level
 
 			// Consider window tab's where clause if any
-			final I_AD_Tab huTab = Services.get(IADWindowDAO.class).retrieveFirstTab(WEBUI_HU_Constants.WEBUI_HU_Window_ID.toAdWindowId());
+			final I_AD_Tab huTab = Services.get(IADWindowDAO.class).retrieveFirstTab(WEBUI_HU_Constants.WEBUI_HU_Window_ID.toInt());
 			if (!Check.isEmpty(huTab.getWhereClause(), true))
 			{
 				sqlWhereClause.append("\n AND (").append(huTab.getWhereClause()).append(")");

--- a/src/main/java/de/metas/ui/web/pickingslotsClearing/PickingSlotsClearingViewFactory.java
+++ b/src/main/java/de/metas/ui/web/pickingslotsClearing/PickingSlotsClearingViewFactory.java
@@ -84,7 +84,7 @@ public class PickingSlotsClearingViewFactory implements IViewFactory
 
 		return ViewLayout.builder()
 				.setWindowId(WINDOW_ID)
-				.setCaption(Services.get(IADWindowDAO.class).retrieveWindowName(WINDOW_ID.toAdWindowId()))
+				.setCaption(Services.get(IADWindowDAO.class).retrieveWindowName(WINDOW_ID.toInt()))
 				.addElementsFromViewRowClass(PickingSlotRow.class, viewDataType)
 				.setHasTreeSupport(true)
 				.setFilters(getFilterDescriptorsProvider().getAll())

--- a/src/main/java/de/metas/ui/web/process/adprocess/ADProcessInstancesRepository.java
+++ b/src/main/java/de/metas/ui/web/process/adprocess/ADProcessInstancesRepository.java
@@ -8,7 +8,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.api.IRangeAwareParams;
 import org.adempiere.util.lang.IAutoCloseable;
@@ -207,7 +206,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 		final String tableName;
 		final int recordId;
 		final String sqlWhereClause;
-		final AdWindowId adWindowId;
+		final int adWindowId;
 
 		//
 		// View
@@ -218,7 +217,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 			final IView view = viewsRepo.getView(viewId);
 			final DocumentIdsSelection viewDocumentIds = viewRowIdsSelection.getRowIds();
 
-			adWindowId = viewId.getWindowId().toAdWindowIdOrNull();
+			adWindowId = viewId.getWindowId().toIntOr(-1);
 
 			if (viewDocumentIds.isSingleDocumentId())
 			{
@@ -259,7 +258,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 		{
 			final DocumentEntityDescriptor entityDescriptor = documentDescriptorFactory.getDocumentEntityDescriptor(singleDocumentPath);
 
-			adWindowId = singleDocumentPath.getWindowId().toAdWindowIdOrNull();
+			adWindowId = singleDocumentPath.getWindowId().toIntOr(-1);
 
 			tableName = entityDescriptor.getTableNameOrNull();
 			if (singleDocumentPath.isRootDocument())
@@ -281,7 +280,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 			tableName = null;
 			recordId = -1;
 			sqlWhereClause = null;
-			adWindowId = null;
+			adWindowId = -1;
 		}
 
 		//
@@ -294,7 +293,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 				.setCtx(Env.getCtx())
 				.setCreateTemporaryCtx()
 				.setAD_Process_ID(request.getProcessIdAsInt())
-				.setAdWindowId(adWindowId)
+				.setAD_Window_ID(adWindowId)
 				.setRecord(tableName, recordId)
 				.setSelectedIncludedRecords(selectedIncludedRecords)
 				.setWhereClause(sqlWhereClause);

--- a/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -206,7 +206,7 @@ public class ADProcessPostProcessService
 		WindowId windowId = WindowId.fromNullableJson(recordsToOpen.getWindowIdString());
 		if (windowId == null)
 		{
-			windowId = WindowId.ofNullable(RecordZoomWindowFinder.findAdWindowId(recordRef).orElse(null));
+			windowId = WindowId.ofIntOrNull(RecordZoomWindowFinder.findAD_Window_ID(recordRef));
 		}
 
 		return DocumentPath.rootDocumentPath(windowId, documentId);
@@ -239,14 +239,14 @@ public class ADProcessPostProcessService
 			}
 
 			final TableRecordReference firstRecordRef = TableRecordReference.of(tableName, recordIds.get(0));
-			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAdWindowId(firstRecordRef).get()); // assume all records are from same window
+			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAD_Window_ID(firstRecordRef)); // assume all records are from same window
 			return recordIds.stream()
 					.map(recordId -> DocumentPath.rootDocumentPath(windowId, recordId))
 					.collect(ImmutableSet.toImmutableSet());
 		}
 		else if (sourceRecordRef != null)
 		{
-			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAdWindowId(sourceRecordRef).get());
+			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAD_Window_ID(sourceRecordRef));
 			final DocumentPath documentPath = DocumentPath.rootDocumentPath(windowId, sourceRecordRef.getRecord_ID());
 			return ImmutableSet.of(documentPath);
 		}
@@ -274,7 +274,7 @@ public class ADProcessPostProcessService
 		final Map<WindowId, CreateViewRequest.Builder> viewRequestBuilders = new HashMap<>();
 		for (final TableRecordReference recordRef : recordRefs)
 		{
-			final WindowId recordWindowId = windowId_Override != null ? windowId_Override : WindowId.ofNullable(RecordZoomWindowFinder.findAdWindowId(recordRef).orElse(null));
+			final WindowId recordWindowId = windowId_Override != null ? windowId_Override : WindowId.ofIntOrNull(RecordZoomWindowFinder.findAD_Window_ID(recordRef));
 			final CreateViewRequest.Builder viewRequestBuilder = viewRequestBuilders.computeIfAbsent(recordWindowId, key -> CreateViewRequest.builder(recordWindowId, JSONViewDataType.grid));
 
 			viewRequestBuilder.addFilterOnlyId(recordRef.getRecord_ID());

--- a/src/main/java/de/metas/ui/web/window/controller/DocumentPermissionsHelper.java
+++ b/src/main/java/de/metas/ui/web/window/controller/DocumentPermissionsHelper.java
@@ -2,7 +2,6 @@ package de.metas.ui.web.window.controller;
 
 import javax.annotation.Nullable;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ClientId;
@@ -54,7 +53,7 @@ public class DocumentPermissionsHelper
 
 	public static ElementPermission checkWindowAccess(@NonNull final DocumentEntityDescriptor entityDescriptor, final IUserRolePermissions permissions)
 	{
-		final AdWindowId adWindowId = entityDescriptor.getWindowId().toAdWindowId();
+		final int adWindowId = entityDescriptor.getWindowId().toInt();
 		final ElementPermission windowPermission = permissions.checkWindowPermission(adWindowId);
 		final boolean readAccess = windowPermission.hasReadAccess();
 		final boolean writeAccess = windowPermission.hasWriteAccess();
@@ -82,8 +81,8 @@ public class DocumentPermissionsHelper
 	 */
 	public static void assertViewAccess(final WindowId windowId, @Nullable final String viewId, final IUserRolePermissions permissions)
 	{
-		final AdWindowId adWindowId = windowId.toAdWindowIdOrNull();
-		if (adWindowId == null)
+		final int adWindowId = windowId.toIntOr(-1);
+		if (adWindowId < 0)
 		{
 			// cannot apply window access if the WindowId is not integer.
 			// usually those are special window placeholders.
@@ -106,7 +105,7 @@ public class DocumentPermissionsHelper
 
 	private static void logAccessIfWindowExistsAndThrowEx(
 			@NonNull final IUserRolePermissions permissions,
-			@NonNull final AdWindowId adWindowId,
+			final int adWindowId,
 			@NonNull final AdempiereException ex)
 	{
 		final IRolePermLoggingBL rolePermLoggingBL = Services.get(IRolePermLoggingBL.class);
@@ -132,8 +131,9 @@ public class DocumentPermissionsHelper
 		}
 
 		// Check if we have window read permission
-		final AdWindowId adWindowId = document.getDocumentPath().getWindowId().toAdWindowIdOrNull();
-		if (adWindowId != null && !permissions.checkWindowPermission(adWindowId).hasReadAccess())
+		final WindowId windowId = document.getDocumentPath().getWindowId();
+		final int windowIdInt = windowId.toIntOr(-1);
+		if (windowIdInt > 0 && !permissions.checkWindowPermission(windowIdInt).hasReadAccess())
 		{
 			throw DocumentPermissionException.of(DocumentPermission.View, "no window read permission");
 		}
@@ -190,8 +190,9 @@ public class DocumentPermissionsHelper
 		}
 
 		// Check if we have window write permission
-		final AdWindowId adWindowId = documentPath.getWindowId().toAdWindowIdOrNull();
-		if (adWindowId != null && !permissions.checkWindowPermission(adWindowId).hasWriteAccess())
+		final WindowId windowId = documentPath.getWindowId();
+		final int windowIdInt = windowId.toIntOr(-1);
+		if (windowIdInt > 0 && !permissions.checkWindowPermission(windowIdInt).hasWriteAccess())
 		{
 			return "no window edit permission";
 		}

--- a/src/main/java/de/metas/ui/web/window/datatypes/DocumentPath.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/DocumentPath.java
@@ -43,12 +43,12 @@ import lombok.NonNull;
 @Immutable
 public final class DocumentPath
 {
-	public static Builder builder()
+	public static final Builder builder()
 	{
 		return new Builder();
 	}
 
-	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final int documentIdInt)
+	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final int documentIdInt)
 	{
 		final DocumentId documentId = DocumentId.of(documentIdInt);
 		if (documentId.isNew())
@@ -58,12 +58,12 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final RepoIdAware documentRepoId)
+	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final RepoIdAware documentRepoId)
 	{
 		return rootDocumentPath(windowId, documentRepoId.getRepoId());
 	}
 
-	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final String documentIdStr)
+	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final String documentIdStr)
 	{
 		final DocumentId documentId = DocumentId.of(documentIdStr);
 		if (documentId.isNew())
@@ -73,7 +73,7 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
+	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
 	{
 		if (documentId.isNew())
 		{
@@ -82,7 +82,7 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static DocumentPath rootDocumentPath(final DocumentType documentType, final DocumentId documentTypeId, final DocumentId documentId)
+	public static final DocumentPath rootDocumentPath(final DocumentType documentType, final DocumentId documentTypeId, final DocumentId documentId)
 	{
 		if (documentId == null || documentId.isNew())
 		{
@@ -92,7 +92,7 @@ public final class DocumentPath
 		return new DocumentPath(documentType, documentTypeId, documentId);
 	}
 
-	public static List<DocumentPath> rootDocumentPathsList(final WindowId windowId, final String documentIdsListStr)
+	public static final List<DocumentPath> rootDocumentPathsList(final WindowId windowId, final String documentIdsListStr)
 	{
 		if (documentIdsListStr == null || documentIdsListStr.isEmpty())
 		{
@@ -105,7 +105,7 @@ public final class DocumentPath
 				.collect(GuavaCollectors.toImmutableList());
 	}
 
-	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, final String idStr, final String detailId, final String rowIdStr)
+	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, final String idStr, final String detailId, final String rowIdStr)
 	{
 		if (Check.isEmpty(detailId, true))
 		{
@@ -124,7 +124,7 @@ public final class DocumentPath
 				.build();
 	}
 
-	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId, @NonNull final DocumentId rowId)
+	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId, @NonNull final DocumentId rowId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -134,7 +134,7 @@ public final class DocumentPath
 				.build();
 	}
 
-	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId)
+	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -147,7 +147,7 @@ public final class DocumentPath
 	/**
 	 * Creates the path of a single document (root document or included document).
 	 */
-	public static DocumentPath singleWindowDocumentPath(@NonNull final WindowId windowId, final DocumentId id, final DetailId detailId, final DocumentId rowId)
+	public static final DocumentPath singleWindowDocumentPath(@NonNull final WindowId windowId, final DocumentId id, final DetailId detailId, final DocumentId rowId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -289,6 +289,18 @@ public final class DocumentPath
 	public WindowId getWindowIdOrNull()
 	{
 		return documentType == DocumentType.Window ? WindowId.of(documentTypeId) : null;
+	}
+
+	public int getAD_Window_ID(final int returnIfNotAvailable)
+	{
+		if (documentType == DocumentType.Window)
+		{
+			return documentTypeId.toIntOr(returnIfNotAvailable);
+		}
+		else
+		{
+			return returnIfNotAvailable;
+		}
 	}
 
 	public AdWindowId getAdWindowIdOrNull()

--- a/src/main/java/de/metas/ui/web/window/datatypes/WindowId.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/WindowId.java
@@ -1,7 +1,5 @@
 package de.metas.ui.web.window.datatypes;
 
-import javax.annotation.Nullable;
-
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 
@@ -11,7 +9,6 @@ import com.google.common.base.Preconditions;
 
 import de.metas.util.Check;
 import lombok.EqualsAndHashCode;
-import lombok.NonNull;
 
 /*
  * #%L
@@ -38,12 +35,12 @@ import lombok.NonNull;
 @EqualsAndHashCode
 public final class WindowId
 {
-	public static WindowId fromJson(final String json)
+	public static final WindowId fromJson(final String json)
 	{
 		return new WindowId(json);
 	}
 
-	public static WindowId fromNullableJson(final String json)
+	public static final WindowId fromNullableJson(final String json)
 	{
 		if (json == null)
 		{
@@ -52,14 +49,9 @@ public final class WindowId
 		return new WindowId(json);
 	}
 
-	public static WindowId of(final int windowIdInt)
+	public static final WindowId of(final int windowIdInt)
 	{
 		return new WindowId(windowIdInt);
-	}
-
-	public static WindowId of(@NonNull final AdWindowId adWindowId)
-	{
-		return new WindowId(adWindowId.getRepoId());
 	}
 
 	public static WindowId of(final DocumentId documentTypeId)
@@ -74,9 +66,13 @@ public final class WindowId
 		}
 	}
 
-	public static WindowId ofNullable(@Nullable final AdWindowId adWindowId)
+	public static final WindowId ofIntOrNull(final int windowIdInt)
 	{
-		return adWindowId != null ? new WindowId(adWindowId.getRepoId()) : null;
+		if (windowIdInt <= 0)
+		{
+			return null;
+		}
+		return new WindowId(windowIdInt);
 	}
 
 	private final String value;
@@ -142,11 +138,6 @@ public final class WindowId
 	public AdWindowId toAdWindowIdOrNull()
 	{
 		return AdWindowId.ofRepoIdOrNull(toIntOr(-1));
-	}
-
-	public AdWindowId toAdWindowId()
-	{
-		return AdWindowId.ofRepoId(toInt());
 	}
 
 	public boolean isInt()

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
@@ -22,7 +22,6 @@ import org.adempiere.ad.callout.api.impl.NullCalloutExecutor;
 import org.adempiere.ad.callout.spi.ICalloutProvider;
 import org.adempiere.ad.callout.spi.ImmutablePlainCalloutProvider;
 import org.adempiere.ad.element.api.AdTabId;
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ConstantLogicExpression;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.ad.ui.api.ITabCalloutFactory;
@@ -796,9 +795,10 @@ public class DocumentEntityDescriptor
 			return this;
 		}
 
-		public Builder setDocumentType(@NonNull final AdWindowId adWindowId)
+		public Builder setDocumentType(final DocumentType documentType, final int documentTypeIdInt)
 		{
-			return setDocumentType(DocumentType.Window, DocumentId.of(adWindowId.getRepoId()));
+			setDocumentType(documentType, DocumentId.of(documentTypeIdInt));
+			return this;
 		}
 
 		public DocumentType getDocumentType()

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/ADTabLoader.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/ADTabLoader.java
@@ -1,6 +1,5 @@
 package de.metas.ui.web.window.descriptor.factory.standard;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.compiere.model.GridTabVO;
 import org.compiere.model.GridWindowVO;
 
@@ -37,7 +36,7 @@ import lombok.Value;
 @Builder
 public class ADTabLoader
 {
-	AdWindowId adWindowId;
+	int adWindowId;
 
 	@NonNull
 	LayoutFactory rootLayoutFactory;

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorFactory.java
@@ -76,7 +76,7 @@ public class DefaultDocumentDescriptorFactory implements DocumentDescriptorFacto
 	private DefaultDocumentDescriptorLoader createDocumentDescriptorLoader(@NonNull final WindowId windowId)
 	{
 		return new DefaultDocumentDescriptorLoader(
-				windowId.toAdWindowId(),
+				windowId.toInt(),
 				dataEntrySubTabBindingDescriptorBuilder);
 	}
 

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorLoader.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorLoader.java
@@ -49,7 +49,7 @@ import lombok.NonNull;
 
 	//
 	// Parameters
-	private final AdWindowId adWindowId;
+	private final int AD_Window_ID;
 
 	private final DataEntrySubTabBindingDescriptorBuilder dataEntrySubTabBindingDescriptorBuilder;
 
@@ -59,10 +59,10 @@ import lombok.NonNull;
 
 
 	/* package */ DefaultDocumentDescriptorLoader(
-			final AdWindowId adWindowId,
+			final int AD_Window_ID,
 			@NonNull final DataEntrySubTabBindingDescriptorBuilder dataEntrySubTabBindingDescriptorBuilder)
 	{
-		this.adWindowId = adWindowId;
+		this.AD_Window_ID = AD_Window_ID;
 		this.dataEntrySubTabBindingDescriptorBuilder = dataEntrySubTabBindingDescriptorBuilder;
 	}
 
@@ -75,20 +75,20 @@ import lombok.NonNull;
 		}
 		_executed = true;
 
-		if (adWindowId == null)
+		if (AD_Window_ID <= 0)
 		{
-			throw new DocumentLayoutBuildException("No window found for AD_Window_ID=" + adWindowId);
+			throw new DocumentLayoutBuildException("No window found for AD_Window_ID=" + AD_Window_ID);
 		}
 
 		final Stopwatch stopwatch = Stopwatch.createStarted();
 
-		final GridWindowVO gridWindowVO = DocumentLoaderUtil.createGridWindoVO(adWindowId);
+		final GridWindowVO gridWindowVO = DocumentLoaderUtil.createGridWindoVO(AD_Window_ID);
 		Check.assumeNotNull(gridWindowVO, "Parameter gridWindowVO is not null"); // shall never happen
 
 		final DocumentDescriptor.Builder documentBuilder = DocumentDescriptor.builder();
 
 		final DocumentLayoutDescriptor.Builder layoutBuilder = DocumentLayoutDescriptor.builder()
-				.setWindowId(WindowId.of(gridWindowVO.getAdWindowId()))
+				.setWindowId(WindowId.of(gridWindowVO.getAD_Window_ID()))
 				.setStopwatch(stopwatch)
 				.putDebugProperty("generator-name", toString());
 
@@ -109,8 +109,10 @@ import lombok.NonNull;
 					.setDocActionElement(rootLayoutFactory.createSpecialElement_DocStatusAndDocAction());
 		}
 
+		final AdWindowId adWindowId = AdWindowId.ofRepoId(AD_Window_ID);
+
 		ADTabLoader.builder()
-				.adWindowId(adWindowId)
+				.adWindowId(adWindowId.getRepoId())
 				.rootLayoutFactory(rootLayoutFactory)
 				.layoutBuilder(layoutBuilder)
 				.build()

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DocumentLoaderUtil.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DocumentLoaderUtil.java
@@ -1,6 +1,5 @@
 package de.metas.ui.web.window.descriptor.factory.standard;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.compiere.model.GridWindowVO;
 import org.compiere.util.Env;
 
@@ -31,12 +30,12 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class DocumentLoaderUtil
 {
-	public GridWindowVO createGridWindoVO(final AdWindowId adWindowId)
+	public GridWindowVO createGridWindoVO(final int AD_Window_ID)
 	{
 		final GridWindowVO gridWindowVO = GridWindowVO.builder()
 				.ctx(Env.getCtx())
 				.windowNo(0) // TODO: get rid of WindowNo from GridWindowVO
-				.adWindowId(adWindowId)
+				.adWindowId(AD_Window_ID)
 				.adMenuId(-1) // N/A
 				.loadAllLanguages(true)
 				.applyRolePermissions(false)

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
@@ -39,6 +39,7 @@ import de.metas.ui.web.process.ProcessId;
 import de.metas.ui.web.session.WebRestApiContextProvider;
 import de.metas.ui.web.window.WindowConstants;
 import de.metas.ui.web.window.datatypes.DataTypes;
+import de.metas.ui.web.window.datatypes.DocumentType;
 import de.metas.ui.web.window.descriptor.ButtonFieldActionDescriptor;
 import de.metas.ui.web.window.descriptor.ButtonFieldActionDescriptor.ButtonFieldActionType;
 import de.metas.ui.web.window.descriptor.DetailId;
@@ -211,7 +212,7 @@ import lombok.NonNull;
 		//
 		// Entity descriptor
 		final DocumentEntityDescriptor.Builder entityDescriptorBuilder = DocumentEntityDescriptor.builder()
-				.setDocumentType(gridTabVO.getAdWindowId())
+				.setDocumentType(DocumentType.Window, gridTabVO.getAD_Window_ID())
 				.setDetailId(detailId)
 				.setInternalName(gridTabVO.getInternalName())
 				//

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
@@ -10,7 +10,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import org.adempiere.ad.element.api.AdTabId;
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
@@ -118,7 +117,7 @@ public class LayoutFactory
 	//
 	// Parameters
 	private final GridTabVOBasedDocumentEntityDescriptorFactory descriptorsFactory;
-	private final AdWindowId _adWindowId;
+	private final int _adWindowId;
 	private final ITranslatableString windowCaption;
 
 	private final ImmutableSet<Integer> childAdTabIdsToSkip;
@@ -135,7 +134,7 @@ public class LayoutFactory
 	{
 		SpringContextHolder.instance.autowire(this);
 
-		_adWindowId = gridTabVO.getAdWindowId();
+		_adWindowId = gridTabVO.getAD_Window_ID();
 		windowCaption = TranslatableStrings.ofMap(gridWindowVO.getNameTrls(), gridWindowVO.getName());
 
 		final AdTabId templateTabId = AdTabId.ofRepoId(CoalesceUtil.firstGreaterThanZero(gridTabVO.getTemplateTabId(), gridTabVO.getAD_Tab_ID()));
@@ -206,7 +205,7 @@ public class LayoutFactory
 				.flatMap(uiElementGroup -> getUIProvider().getUIElements(uiElementGroup).stream());
 	}
 
-	private AdWindowId getAdWindowId()
+	private int getAD_Window_ID()
 	{
 		return _adWindowId;
 	}
@@ -688,7 +687,7 @@ public class LayoutFactory
 	public final ViewLayout layoutSideListView()
 	{
 		final ViewLayout.Builder layoutBuilder = ViewLayout.builder()
-				.setWindowId(WindowId.of(getAdWindowId()))
+				.setWindowId(WindowId.of(getAD_Window_ID()))
 				.setEmptyResultText(HARDCODED_TAB_EMPTY_RESULT_TEXT)
 				.setEmptyResultHint(HARDCODED_TAB_EMPTY_RESULT_HINT);
 

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import javax.annotation.concurrent.Immutable;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ICachedStringExpression;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.api.TranslatableParameterizedStringExpression;
@@ -79,17 +78,17 @@ import de.metas.util.Check;
 @Immutable
 public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 {
-	public static Builder builder()
+	public static final Builder builder()
 	{
 		return new Builder();
 	}
 
-	public static SqlLookupDescriptor cast(final LookupDescriptor descriptor)
+	public static final SqlLookupDescriptor cast(final LookupDescriptor descriptor)
 	{
 		return (SqlLookupDescriptor)descriptor;
 	}
 
-	public static LookupDescriptorProvider searchInTable(final String lookupTableName)
+	public static final LookupDescriptorProvider searchInTable(final String lookupTableName)
 	{
 		return builder()
 				.setCtxTableName(null) // tableName
@@ -99,7 +98,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 				.buildProvider();
 	}
 
-	public static LookupDescriptorProvider listByAD_Reference_Value_ID(final int AD_Reference_Value_ID)
+	public static final LookupDescriptorProvider listByAD_Reference_Value_ID(final int AD_Reference_Value_ID)
 	{
 		Check.assumeGreaterThanZero(AD_Reference_Value_ID, "AD_Reference_Value_ID");
 
@@ -116,7 +115,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 	 * @param AD_Reference_Value_ID has to be > 0
 	 * @param AD_Val_Rule_ID may be <= 0
 	 */
-	public static LookupDescriptorProvider searchByAD_Val_Rule_ID(
+	public static final LookupDescriptorProvider searchByAD_Val_Rule_ID(
 			final int AD_Reference_Value_ID,
 			final int AD_Val_Rule_ID)
 	{
@@ -149,10 +148,11 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 	private final boolean highVolume;
 	private final boolean numericKey;
-
 	private final LookupSource lookupSourceType;
+
 	private final ImmutableSet<String> dependsOnFieldNames;
 	private final ImmutableSet<String> dependsOnTableNames;
+
 	private final GenericSqlLookupDataSourceFetcher lookupDataSourceFetcher;
 
 	private SqlLookupDescriptor(final Builder builder)
@@ -167,10 +167,11 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		numericKey = builder.numericKey;
 		highVolume = builder.isHighVolume();
-
 		lookupSourceType = builder.getLookupSourceType();
+
 		dependsOnFieldNames = ImmutableSet.copyOf(builder.dependsOnFieldNames);
 		dependsOnTableNames = ImmutableSet.copyOf(builder.getDependsOnTableNames());
+
 		lookupDataSourceFetcher = GenericSqlLookupDataSourceFetcher.of(this); // keep it last!
 	}
 
@@ -180,7 +181,6 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 		return MoreObjects.toStringHelper(this)
 				.omitNullValues()
 				.add("tableName", tableName)
-				.add("zoomIntoWindowId", zoomIntoWindowId.orElse(null))
 				.add("highVolume", highVolume ? highVolume : null)
 				.add("sqlForFetching", sqlForFetchingExpression.toOneLineString())
 				.add("postQueryPredicate", postQueryPredicate == null || postQueryPredicate == INamePairPredicate.NULL ? null : postQueryPredicate)
@@ -192,7 +192,6 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 	{
 		return Objects.hash(
 				tableName,
-				zoomIntoWindowId,
 				sqlForFetchingExpression,
 				sqlForFetchingLookupByIdExpression,
 				entityTypeIndex,
@@ -225,7 +224,6 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		final SqlLookupDescriptor other = (SqlLookupDescriptor)obj;
 		return Objects.equals(tableName, other.tableName)
-				&& Objects.equals(zoomIntoWindowId, other.zoomIntoWindowId)
 				&& Objects.equals(sqlForFetchingExpression, other.sqlForFetchingExpression)
 				&& Objects.equals(sqlForFetchingLookupByIdExpression, other.sqlForFetchingLookupByIdExpression)
 				&& entityTypeIndex == other.entityTypeIndex
@@ -349,10 +347,11 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 		private ICachedStringExpression sqlForFetchingLookupByIdExpression;
 		private int entityTypeIndex = -1;
 
-		private AdWindowId zoomIntoAdWindowId = null;
+		private int zoomIntoWindowId = -1;
 
 		private Builder()
 		{
+			super();
 		}
 
 		public LookupDescriptorProvider buildProvider()
@@ -471,7 +470,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			// Set the SQLs
 			{
 				sqlTableName = lookupInfo.getTableName();
-				zoomIntoAdWindowId = lookupInfo.getZoomAD_Window_ID_Override();
+				zoomIntoWindowId = lookupInfo.getZoomAD_Window_ID_Override();
 				sqlForFetchingExpression = buildSqlForFetching(lookupInfo, sqlWhereFinal, lookup_SqlOrderBy)
 						.caching();
 				sqlForFetchingLookupByIdExpression = buildSqlForFetchingById(lookupInfo)
@@ -550,7 +549,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			}
 		}
 
-		private static IStringExpression buildSqlWhere(final MLookupInfo lookupInfo, final LookupScope scope, final IValidationRule validationRuleEffective)
+		private static final IStringExpression buildSqlWhere(final MLookupInfo lookupInfo, final LookupScope scope, final IValidationRule validationRuleEffective)
 		{
 			final String tableName = lookupInfo.getTableName();
 			final String lookup_SqlWhere = lookupInfo.getWhereClauseSqlPart();
@@ -586,7 +585,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return sqlWhereFinal.build();
 		}
 
-		private static IStringExpression buildSqlWhereClauseFromValidationRule(final IValidationRule validationRule, final LookupScope scope)
+		private static final IStringExpression buildSqlWhereClauseFromValidationRule(final IValidationRule validationRule, final LookupScope scope)
 		{
 			final IStringExpression validationRuleWhereClause = validationRule.getPrefilterWhereClause();
 			if (validationRuleWhereClause.isNullExpression())
@@ -603,7 +602,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return validationRuleWhereClause;
 		}
 
-		private IStringExpression buildSqlForFetching(final MLookupInfo lookupInfo, final IStringExpression sqlWhere, final String sqlOrderBy)
+		private final IStringExpression buildSqlForFetching(final MLookupInfo lookupInfo, final IStringExpression sqlWhere, final String sqlOrderBy)
 		{
 			final String tableName = lookupInfo.getTableName();
 			return IStringExpression.composer()
@@ -722,7 +721,8 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		public Optional<WindowId> getZoomIntoWindowId()
 		{
-			return Optional.ofNullable(WindowId.ofNullable(zoomIntoAdWindowId));
+			final WindowId windowId = zoomIntoWindowId > 0 ? WindowId.of(zoomIntoWindowId) : null;
+			return Optional.ofNullable(windowId);
 		}
 
 		private LookupSource getLookupSourceType()
@@ -737,7 +737,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return this;
 		}
 
-		private Access getRequiredAccess(final String tableName)
+		private final Access getRequiredAccess(final String tableName)
 		{
 			if (requiredAccess != null)
 			{

--- a/src/main/java/de/metas/ui/web/window/model/Document.java
+++ b/src/main/java/de/metas/ui/web/window/model/Document.java
@@ -20,7 +20,6 @@ import javax.annotation.Nullable;
 
 import org.adempiere.ad.callout.api.ICalloutExecutor;
 import org.adempiere.ad.callout.api.ICalloutRecord;
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.IExpression;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.ILogicExpression;
@@ -95,7 +94,7 @@ import lombok.NonNull;
 
 public final class Document
 {
-	public static Builder builder(final DocumentEntityDescriptor entityDescriptor)
+	public static final Builder builder(final DocumentEntityDescriptor entityDescriptor)
 	{
 		return new Builder(entityDescriptor);
 	}
@@ -160,7 +159,7 @@ public final class Document
 	// Misc
 	private Map<String, Object> _dynAttributes = null; // lazy
 
-	public interface DocumentValuesSupplier
+	public static interface DocumentValuesSupplier
 	{
 		Object NO_VALUE = new String("NO_VALUE");
 
@@ -405,7 +404,7 @@ public final class Document
 		return _writable;
 	}
 
-	private void initializeFields(final FieldInitializationMode mode, final DocumentValuesSupplier documentValuesSupplier)
+	private final void initializeFields(final FieldInitializationMode mode, final DocumentValuesSupplier documentValuesSupplier)
 	{
 		logger.trace("Initializing fields: mode={}", mode);
 
@@ -658,7 +657,7 @@ public final class Document
 			return parentSupplier.getVersion();
 		}
 
-		private IDocumentEvaluatee getEvaluatee(final DocumentFieldDescriptor fieldInScope)
+		private final IDocumentEvaluatee getEvaluatee(final DocumentFieldDescriptor fieldInScope)
 		{
 			if (fieldInScope == null)
 			{
@@ -734,7 +733,7 @@ public final class Document
 			if (documentType == DocumentType.Window && !fieldDescriptor.isVirtualField())
 			{
 				final Properties ctx = Env.getCtx();
-				final AdWindowId adWindowId = documentTypeId.toId(AdWindowId::ofRepoId);
+				final int adWindowId = documentTypeId.toInt();
 				final String fieldName = fieldDescriptor.getFieldName();
 
 				//
@@ -766,7 +765,7 @@ public final class Document
 		}
 	}
 
-	public enum CopyMode
+	public static enum CopyMode
 	{
 		CheckOutWritable(true), CheckInReadonly(false);
 
@@ -794,7 +793,7 @@ public final class Document
 		return new Document(this, parentDocumentCopy, copyMode, parentDocumentCopy.changesCollector);
 	}
 
-	/* package */void assertWritable()
+	/* package */final void assertWritable()
 	{
 		if (isInitializing())
 		{
@@ -823,7 +822,7 @@ public final class Document
 	}
 
 	@Override
-	public String toString()
+	public final String toString()
 	{
 		// NOTE: keep it short
 
@@ -1073,7 +1072,7 @@ public final class Document
 		return _valid;
 	}
 
-	private DocumentValidStatus setValidStatusAndReturn(final DocumentValidStatus valid, final OnValidStatusChanged onValidStatusChanged)
+	private final DocumentValidStatus setValidStatusAndReturn(final DocumentValidStatus valid, final OnValidStatusChanged onValidStatusChanged)
 	{
 		Preconditions.checkNotNull(valid, "valid"); // shall not happen
 
@@ -1108,7 +1107,7 @@ public final class Document
 		return _saveStatus;
 	}
 
-	private DocumentSaveStatus setSaveStatusAndReturn(@NonNull final DocumentSaveStatus saveStatus)
+	private final DocumentSaveStatus setSaveStatusAndReturn(@NonNull final DocumentSaveStatus saveStatus)
 	{
 		_saveStatus = saveStatus;
 		final DocumentSaveStatus saveStatusOnCheckoutOld = _saveStatusOnCheckout;
@@ -1212,7 +1211,7 @@ public final class Document
 		setValue(documentField, value, reason);
 	}
 
-	private void setValue(final IDocumentField documentField, final Object value, final ReasonSupplier reason)
+	private final void setValue(final IDocumentField documentField, final Object value, final ReasonSupplier reason)
 	{
 		assertWritable();
 
@@ -1309,7 +1308,7 @@ public final class Document
 		getFields().forEach(documentField -> updateFieldReadOnlyAndCollect(documentField, reason));
 	}
 
-	private DocumentReadonly computeReadonly()
+	private final DocumentReadonly computeReadonly()
 	{
 		final ILogicExpression allFieldsReadonlyLogic = getEntityDescriptor().getReadonlyLogic();
 		LogicExpressionResult allFieldsReadonly;
@@ -1332,7 +1331,7 @@ public final class Document
 		return readonlyComputed;
 	}
 
-	private void updateFieldReadOnlyAndCollect(final IDocumentField documentField, final ReasonSupplier reason)
+	private final void updateFieldReadOnlyAndCollect(final IDocumentField documentField, final ReasonSupplier reason)
 	{
 		final LogicExpressionResult readonlyOld = documentField.getReadonly();
 		final LogicExpressionResult readonlyNew = computeFieldReadOnly(documentField);
@@ -1343,7 +1342,7 @@ public final class Document
 		}
 	}
 
-	private LogicExpressionResult computeFieldReadOnly(final IDocumentField documentField)
+	private final LogicExpressionResult computeFieldReadOnly(final IDocumentField documentField)
 	{
 		// Check document's readonly logic
 		final DocumentReadonly documentReadonlyLogic = getReadonly();
@@ -1367,7 +1366,7 @@ public final class Document
 
 	}
 
-	private void updateFieldDisplayed(final IDocumentField documentField)
+	private final void updateFieldDisplayed(final IDocumentField documentField)
 	{
 		LogicExpressionResult displayed = LogicExpressionResult.FALSE; // default false, i.e. not displayed
 		final ILogicExpression displayLogic = documentField.getDescriptor().getDisplayLogic();
@@ -1384,7 +1383,7 @@ public final class Document
 		documentField.setDisplayed(displayed);
 	}
 
-	private void updateFieldsWhichDependsOn(final String triggeringFieldName)
+	private final void updateFieldsWhichDependsOn(final String triggeringFieldName)
 	{
 		final DocumentFieldDependencyMap dependencies = getEntityDescriptor().getDependencies();
 		dependencies.consumeForChangedFieldName(triggeringFieldName, (dependentFieldName, dependencyType) -> {
@@ -1601,13 +1600,13 @@ public final class Document
 	 * @param name
 	 * @param value
 	 */
-	public Object setDynAttribute(final String name, final Object value)
+	public final Object setDynAttribute(final String name, final Object value)
 	{
 		assertWritable();
 		return setDynAttributeNoCheck(name, value);
 	}
 
-	private Object setDynAttributeNoCheck(final String name, final Object value)
+	private final Object setDynAttributeNoCheck(final String name, final Object value)
 	{
 		Check.assumeNotEmpty(name, "name not empty");
 
@@ -1627,7 +1626,7 @@ public final class Document
 	 * @param name
 	 * @return attribute value or null if not found
 	 */
-	public <T> T getDynAttribute(final String name)
+	public final <T> T getDynAttribute(final String name)
 	{
 		final T defaultValue = null;
 		return getDynAttribute(name, defaultValue);
@@ -1640,7 +1639,7 @@ public final class Document
 	 * @param defaultValue
 	 * @return attribute value or <code>defaultValue</code> if not found
 	 */
-	public <T> T getDynAttribute(final String name, final T defaultValue)
+	public final <T> T getDynAttribute(final String name, final T defaultValue)
 	{
 		if (_dynAttributes == null)
 		{
@@ -1658,7 +1657,7 @@ public final class Document
 		return value;
 	}
 
-	public boolean hasDynAttribute(final String name)
+	public final boolean hasDynAttribute(final String name)
 	{
 		final Map<String, Object> dynAttributes = _dynAttributes;
 		return dynAttributes != null && dynAttributes.get(name) != null;
@@ -1674,14 +1673,14 @@ public final class Document
 		return ImmutableSet.copyOf(dynAttributes.keySet());
 	}
 
-	/* package */ interface OnValidStatusChanged
+	/* package */ static interface OnValidStatusChanged
 	{
 		void onInvalidStatus(Document document, DocumentValidStatus invalidStatus);
 
-		OnValidStatusChanged DO_NOTHING = (document, invalidStatus) -> {
+		public static final OnValidStatusChanged DO_NOTHING = (document, invalidStatus) -> {
 		};
 
-		OnValidStatusChanged MARK_NOT_SAVED = (document, invalidStatus) -> {
+		public static final OnValidStatusChanged MARK_NOT_SAVED = (document, invalidStatus) -> {
 			document.setSaveStatusAndReturn(DocumentSaveStatus.notSaved(invalidStatus));
 		};
 
@@ -1700,7 +1699,7 @@ public final class Document
 	 *
 	 * @param onValidStatusChanged callback to be called when the valid state of this document or of any of it's included documents was changed
 	 */
-	/* package */ DocumentValidStatus checkAndGetValidStatus(final OnValidStatusChanged onValidStatusChanged)
+	/* package */ final DocumentValidStatus checkAndGetValidStatus(final OnValidStatusChanged onValidStatusChanged)
 	{
 		//
 		// Check document fields
@@ -2200,7 +2199,7 @@ public final class Document
 			return build();
 		}
 
-		private DocumentId getDocumentId()
+		private final DocumentId getDocumentId()
 		{
 			return _documentValuesSupplier.getDocumentId();
 		}

--- a/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -11,7 +11,6 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.ad.expression.api.LogicExpressionResult;
@@ -507,9 +506,8 @@ public class DocumentCollection
 		{
 			zoomWindowFinder = RecordZoomWindowFinder.newInstance(zoomIntoInfo.getTableName());
 		}
-		
-		final AdWindowId zoomInto_adWindowId = zoomWindowFinder.findAdWindowId().orElse(null);
-		if (zoomInto_adWindowId == null)
+		final int zoomInto_adWindowId = zoomWindowFinder.findAD_Window_ID();
+		if (zoomInto_adWindowId <= 0)
 		{
 			throw new EntityNotFoundException("No windowId found")
 					.setParameter("zoomIntoInfo", zoomIntoInfo);
@@ -752,7 +750,7 @@ public class DocumentCollection
 		InterfaceWrapperHelper.save(toPO);
 
 		final CopyRecordSupport childCRS = CopyRecordFactory.getCopyRecordSupport(tableName);
-		childCRS.setAdWindowId(fromDocumentPath.getAdWindowIdOrNull());
+		childCRS.setAD_Window_ID(fromDocumentPath.getAD_Window_ID(-1));
 		childCRS.setParentPO(toPO);
 		childCRS.setBase(true);
 		childCRS.copyRecord(fromPO, ITrx.TRXNAME_ThreadInherited);
@@ -819,13 +817,13 @@ public class DocumentCollection
 	@Immutable
 	private static final class DocumentKey
 	{
-		public static DocumentKey of(final Document document)
+		public static final DocumentKey of(final Document document)
 		{
 			final DocumentPath documentPath = document.getDocumentPath();
 			return ofRootDocumentPath(documentPath);
 		}
 
-		public static DocumentKey ofRootDocumentPath(final DocumentPath documentPath)
+		public static final DocumentKey ofRootDocumentPath(final DocumentPath documentPath)
 		{
 			if (!documentPath.isRootDocument())
 			{
@@ -838,7 +836,7 @@ public class DocumentCollection
 			return new DocumentKey(documentPath.getDocumentType(), documentPath.getDocumentTypeId(), documentPath.getDocumentId());
 		}
 
-		public static DocumentKey of(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
+		public static final DocumentKey of(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
 		{
 			return new DocumentKey(DocumentType.Window, windowId.toDocumentId(), documentId);
 		}

--- a/src/main/java/de/metas/ui/web/window/model/DocumentReferencesService.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentReferencesService.java
@@ -5,7 +5,6 @@ import java.util.Properties;
 
 import javax.annotation.Nullable;
 
-import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.ZoomInfoFactory;
@@ -89,7 +88,7 @@ public class DocumentReferencesService
 
 			final DocumentAsZoomSource zoomSource = new DocumentAsZoomSource(sourceDocument);
 
-			final ZoomInfo zoomInfo = ZoomInfoFactory.get().retrieveZoomInfo(zoomSource, targetWindowId.toAdWindowId());
+			final ZoomInfo zoomInfo = ZoomInfoFactory.get().retrieveZoomInfo(zoomSource, targetWindowId.toInt());
 			final ITranslatableString filterCaption = extractFilterCaption(sourceDocument);
 			return createDocumentReference(zoomInfo, filterCaption);
 		});
@@ -137,7 +136,7 @@ public class DocumentReferencesService
 				.id(zoomInfo.getId())
 				.internalName(zoomInfo.getInternalName())
 				.caption(zoomInfo.getLabel())
-				.windowId(WindowId.of(zoomInfo.getAdWindowId()))
+				.windowId(WindowId.of(zoomInfo.getAD_Window_ID()))
 				.documentsCount(zoomInfo.getRecordCount())
 				.filter(MQueryDocumentFilterHelper.createDocumentFilterFromMQuery(zoomInfo.getQuery(), filterCaption))
 				.loadDuration(zoomInfo.getRecordCountDuration())
@@ -149,7 +148,7 @@ public class DocumentReferencesService
 		private final Properties ctx;
 		private final Evaluatee evaluationContext;
 
-		private final AdWindowId adWindowId;
+		private final int adWindowId;
 		private final int adTableId;
 		private final int recordId;
 		private final String keyColumnName;
@@ -168,7 +167,7 @@ public class DocumentReferencesService
 			evaluationContext = document.asEvaluatee();
 
 			final DocumentEntityDescriptor entityDescriptor = document.getEntityDescriptor();
-			adWindowId = entityDescriptor.getWindowId().toAdWindowId();
+			adWindowId = entityDescriptor.getWindowId().toInt();
 			tableName = entityDescriptor.getTableName();
 
 			adTableId = Services.get(IADTableDAO.class).retrieveTableId(tableName);
@@ -232,7 +231,7 @@ public class DocumentReferencesService
 		}
 
 		@Override
-		public AdWindowId getAD_Window_ID()
+		public int getAD_Window_ID()
 		{
 			return adWindowId;
 		}


### PR DESCRIPTION
With PRs metasfresh/metasfresh#5393 and https://github.com/metasfresh/metasfresh-webui-api/pull/1231, the default document type is not anymore when a new sales order is created (other problems as well)
See e.g. `cypress/integration/dunning/create_dunning_candidates.js` in https://dashboard.cypress.io/#/projects/5yp4q1/runs/390/failures