### PR TITLE
Show reversal_id in advanced edit of empties return / receive #5382

### DIFF
--- a/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderScheduler.java
+++ b/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderScheduler.java
@@ -11,6 +11,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ScheduledFuture;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.model.RecordZoomWindowFinder;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_BPartner;
@@ -263,8 +264,8 @@ public class PurchaseCandidateReminderScheduler implements InitializingBean
 
 	private WindowId getWindowId(final String tableName)
 	{
-		final int windowIdInt = RecordZoomWindowFinder.findAD_Window_ID(tableName);
-		return WindowId.of(windowIdInt);
+		final AdWindowId adWindowId = RecordZoomWindowFinder.findAdWindowId(tableName).get();
+		return WindowId.of(adWindowId);
 	}
 
 	private static class RemindersQueue

--- a/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderSchedulerRestController.java
+++ b/src/main/java/de/metas/purchasecandidate/reminder/PurchaseCandidateReminderSchedulerRestController.java
@@ -3,6 +3,7 @@ package de.metas.purchasecandidate.reminder;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.RecordZoomWindowFinder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +60,7 @@ public class PurchaseCandidateReminderSchedulerRestController
 	{
 		userSession.assertLoggedIn();
 
-		final int purchaseCandidatesWindowId = RecordZoomWindowFinder.findAD_Window_ID(I_C_PurchaseCandidate.Table_Name);
+		final AdWindowId purchaseCandidatesWindowId = RecordZoomWindowFinder.findAdWindowId(I_C_PurchaseCandidate.Table_Name).get();
 		if (!userSession.getUserRolePermissions().checkWindowPermission(purchaseCandidatesWindowId).hasWriteAccess())
 		{
 			throw new AdempiereException("No read/write access to purchase candidates window");

--- a/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
+++ b/src/main/java/de/metas/ui/web/board/BoardDescriptorRepository.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.api.impl.CompositeStringExpression;
@@ -176,10 +177,10 @@ public class BoardDescriptorRepository
 
 		//
 		// Board document info
-		int adWindowId = 0; // TODO boardPO.getAD_Window_ID();
-		if (adWindowId <= 0)
+		AdWindowId adWindowId = null; // TODO boardPO.getAD_Window_ID();
+		if (adWindowId == null)
 		{
-			adWindowId = RecordZoomWindowFinder.findAD_Window_ID(tableName);
+			adWindowId = RecordZoomWindowFinder.findAdWindowId(tableName).get();
 		}
 		final WindowId documentWindowId = WindowId.of(adWindowId);
 

--- a/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
+++ b/src/main/java/de/metas/ui/web/dataentry/window/descriptor/factory/DataEntryTabLoader.java
@@ -25,7 +25,6 @@ import de.metas.dataentry.layout.DataEntryTab.DocumentLinkColumnName;
 import de.metas.dataentry.model.I_DataEntry_SubTab;
 import de.metas.dataentry.model.I_DataEntry_Tab;
 import de.metas.i18n.TranslatableStrings;
-import de.metas.ui.web.window.datatypes.DocumentType;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.ui.web.window.descriptor.DetailId;
 import de.metas.ui.web.window.descriptor.DocumentEntityDescriptor;
@@ -325,7 +324,7 @@ public class DataEntryTabLoader
 
 		final DocumentEntityDescriptor documentEntityDescriptor = DocumentEntityDescriptor
 				.builder()
-				.setDocumentType(DocumentType.Window, getAdWindowId().getRepoId())
+				.setDocumentType(getAdWindowId())
 				.setDetailId(createDetailIdFor(dataEntryTab))
 				.setInternalName(dataEntryTab.getInternalName())
 				.setCaption(dataEntryTab.getCaption())
@@ -354,7 +353,7 @@ public class DataEntryTabLoader
 		final DocumentEntityDescriptor.Builder documentEntityDescriptor = DocumentEntityDescriptor
 				.builder()
 				.setSingleRowDetail(true)
-				.setDocumentType(DocumentType.Window, getAdWindowId().getRepoId())
+				.setDocumentType(getAdWindowId())
 				.setDetailId(createDetailIdFor(dataEntrySubTab))
 				.setInternalName(dataEntrySubTab.getInternalName())
 				.setCaption(dataEntrySubTab.getCaption())

--- a/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
+++ b/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
@@ -160,7 +160,7 @@ public abstract class HUEditorViewFactoryTemplate implements IViewFactory
 			sqlWhereClause.append(I_M_HU.COLUMNNAME_M_HU_Item_Parent_ID + " is null"); // top level
 
 			// Consider window tab's where clause if any
-			final I_AD_Tab huTab = Services.get(IADWindowDAO.class).retrieveFirstTab(WEBUI_HU_Constants.WEBUI_HU_Window_ID.toInt());
+			final I_AD_Tab huTab = Services.get(IADWindowDAO.class).retrieveFirstTab(WEBUI_HU_Constants.WEBUI_HU_Window_ID.toAdWindowId());
 			if (!Check.isEmpty(huTab.getWhereClause(), true))
 			{
 				sqlWhereClause.append("\n AND (").append(huTab.getWhereClause()).append(")");

--- a/src/main/java/de/metas/ui/web/pickingslotsClearing/PickingSlotsClearingViewFactory.java
+++ b/src/main/java/de/metas/ui/web/pickingslotsClearing/PickingSlotsClearingViewFactory.java
@@ -84,7 +84,7 @@ public class PickingSlotsClearingViewFactory implements IViewFactory
 
 		return ViewLayout.builder()
 				.setWindowId(WINDOW_ID)
-				.setCaption(Services.get(IADWindowDAO.class).retrieveWindowName(WINDOW_ID.toInt()))
+				.setCaption(Services.get(IADWindowDAO.class).retrieveWindowName(WINDOW_ID.toAdWindowId()))
 				.addElementsFromViewRowClass(PickingSlotRow.class, viewDataType)
 				.setHasTreeSupport(true)
 				.setFilters(getFilterDescriptorsProvider().getAll())

--- a/src/main/java/de/metas/ui/web/process/adprocess/ADProcessInstancesRepository.java
+++ b/src/main/java/de/metas/ui/web/process/adprocess/ADProcessInstancesRepository.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.api.IRangeAwareParams;
 import org.adempiere.util.lang.IAutoCloseable;
@@ -206,7 +207,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 		final String tableName;
 		final int recordId;
 		final String sqlWhereClause;
-		final int adWindowId;
+		final AdWindowId adWindowId;
 
 		//
 		// View
@@ -217,7 +218,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 			final IView view = viewsRepo.getView(viewId);
 			final DocumentIdsSelection viewDocumentIds = viewRowIdsSelection.getRowIds();
 
-			adWindowId = viewId.getWindowId().toIntOr(-1);
+			adWindowId = viewId.getWindowId().toAdWindowIdOrNull();
 
 			if (viewDocumentIds.isSingleDocumentId())
 			{
@@ -258,7 +259,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 		{
 			final DocumentEntityDescriptor entityDescriptor = documentDescriptorFactory.getDocumentEntityDescriptor(singleDocumentPath);
 
-			adWindowId = singleDocumentPath.getWindowId().toIntOr(-1);
+			adWindowId = singleDocumentPath.getWindowId().toAdWindowIdOrNull();
 
 			tableName = entityDescriptor.getTableNameOrNull();
 			if (singleDocumentPath.isRootDocument())
@@ -280,7 +281,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 			tableName = null;
 			recordId = -1;
 			sqlWhereClause = null;
-			adWindowId = -1;
+			adWindowId = null;
 		}
 
 		//
@@ -293,7 +294,7 @@ public class ADProcessInstancesRepository implements IProcessInstancesRepository
 				.setCtx(Env.getCtx())
 				.setCreateTemporaryCtx()
 				.setAD_Process_ID(request.getProcessIdAsInt())
-				.setAD_Window_ID(adWindowId)
+				.setAdWindowId(adWindowId)
 				.setRecord(tableName, recordId)
 				.setSelectedIncludedRecords(selectedIncludedRecords)
 				.setWhereClause(sqlWhereClause);

--- a/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
+++ b/src/main/java/de/metas/ui/web/process/adprocess/ADProcessPostProcessService.java
@@ -206,7 +206,7 @@ public class ADProcessPostProcessService
 		WindowId windowId = WindowId.fromNullableJson(recordsToOpen.getWindowIdString());
 		if (windowId == null)
 		{
-			windowId = WindowId.ofIntOrNull(RecordZoomWindowFinder.findAD_Window_ID(recordRef));
+			windowId = WindowId.ofNullable(RecordZoomWindowFinder.findAdWindowId(recordRef).orElse(null));
 		}
 
 		return DocumentPath.rootDocumentPath(windowId, documentId);
@@ -239,14 +239,14 @@ public class ADProcessPostProcessService
 			}
 
 			final TableRecordReference firstRecordRef = TableRecordReference.of(tableName, recordIds.get(0));
-			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAD_Window_ID(firstRecordRef)); // assume all records are from same window
+			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAdWindowId(firstRecordRef).get()); // assume all records are from same window
 			return recordIds.stream()
 					.map(recordId -> DocumentPath.rootDocumentPath(windowId, recordId))
 					.collect(ImmutableSet.toImmutableSet());
 		}
 		else if (sourceRecordRef != null)
 		{
-			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAD_Window_ID(sourceRecordRef));
+			final WindowId windowId = WindowId.of(RecordZoomWindowFinder.findAdWindowId(sourceRecordRef).get());
 			final DocumentPath documentPath = DocumentPath.rootDocumentPath(windowId, sourceRecordRef.getRecord_ID());
 			return ImmutableSet.of(documentPath);
 		}
@@ -274,7 +274,7 @@ public class ADProcessPostProcessService
 		final Map<WindowId, CreateViewRequest.Builder> viewRequestBuilders = new HashMap<>();
 		for (final TableRecordReference recordRef : recordRefs)
 		{
-			final WindowId recordWindowId = windowId_Override != null ? windowId_Override : WindowId.ofIntOrNull(RecordZoomWindowFinder.findAD_Window_ID(recordRef));
+			final WindowId recordWindowId = windowId_Override != null ? windowId_Override : WindowId.ofNullable(RecordZoomWindowFinder.findAdWindowId(recordRef).orElse(null));
 			final CreateViewRequest.Builder viewRequestBuilder = viewRequestBuilders.computeIfAbsent(recordWindowId, key -> CreateViewRequest.builder(recordWindowId, JSONViewDataType.grid));
 
 			viewRequestBuilder.addFilterOnlyId(recordRef.getRecord_ID());

--- a/src/main/java/de/metas/ui/web/window/controller/DocumentPermissionsHelper.java
+++ b/src/main/java/de/metas/ui/web/window/controller/DocumentPermissionsHelper.java
@@ -2,6 +2,7 @@ package de.metas.ui.web.window.controller;
 
 import javax.annotation.Nullable;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ClientId;
@@ -53,7 +54,7 @@ public class DocumentPermissionsHelper
 
 	public static ElementPermission checkWindowAccess(@NonNull final DocumentEntityDescriptor entityDescriptor, final IUserRolePermissions permissions)
 	{
-		final int adWindowId = entityDescriptor.getWindowId().toInt();
+		final AdWindowId adWindowId = entityDescriptor.getWindowId().toAdWindowId();
 		final ElementPermission windowPermission = permissions.checkWindowPermission(adWindowId);
 		final boolean readAccess = windowPermission.hasReadAccess();
 		final boolean writeAccess = windowPermission.hasWriteAccess();
@@ -81,8 +82,8 @@ public class DocumentPermissionsHelper
 	 */
 	public static void assertViewAccess(final WindowId windowId, @Nullable final String viewId, final IUserRolePermissions permissions)
 	{
-		final int adWindowId = windowId.toIntOr(-1);
-		if (adWindowId < 0)
+		final AdWindowId adWindowId = windowId.toAdWindowIdOrNull();
+		if (adWindowId == null)
 		{
 			// cannot apply window access if the WindowId is not integer.
 			// usually those are special window placeholders.
@@ -105,7 +106,7 @@ public class DocumentPermissionsHelper
 
 	private static void logAccessIfWindowExistsAndThrowEx(
 			@NonNull final IUserRolePermissions permissions,
-			final int adWindowId,
+			@NonNull final AdWindowId adWindowId,
 			@NonNull final AdempiereException ex)
 	{
 		final IRolePermLoggingBL rolePermLoggingBL = Services.get(IRolePermLoggingBL.class);
@@ -131,9 +132,8 @@ public class DocumentPermissionsHelper
 		}
 
 		// Check if we have window read permission
-		final WindowId windowId = document.getDocumentPath().getWindowId();
-		final int windowIdInt = windowId.toIntOr(-1);
-		if (windowIdInt > 0 && !permissions.checkWindowPermission(windowIdInt).hasReadAccess())
+		final AdWindowId adWindowId = document.getDocumentPath().getWindowId().toAdWindowIdOrNull();
+		if (adWindowId != null && !permissions.checkWindowPermission(adWindowId).hasReadAccess())
 		{
 			throw DocumentPermissionException.of(DocumentPermission.View, "no window read permission");
 		}
@@ -190,9 +190,8 @@ public class DocumentPermissionsHelper
 		}
 
 		// Check if we have window write permission
-		final WindowId windowId = documentPath.getWindowId();
-		final int windowIdInt = windowId.toIntOr(-1);
-		if (windowIdInt > 0 && !permissions.checkWindowPermission(windowIdInt).hasWriteAccess())
+		final AdWindowId adWindowId = documentPath.getWindowId().toAdWindowIdOrNull();
+		if (adWindowId != null && !permissions.checkWindowPermission(adWindowId).hasWriteAccess())
 		{
 			return "no window edit permission";
 		}

--- a/src/main/java/de/metas/ui/web/window/datatypes/DocumentPath.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/DocumentPath.java
@@ -43,12 +43,12 @@ import lombok.NonNull;
 @Immutable
 public final class DocumentPath
 {
-	public static final Builder builder()
+	public static Builder builder()
 	{
 		return new Builder();
 	}
 
-	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final int documentIdInt)
+	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final int documentIdInt)
 	{
 		final DocumentId documentId = DocumentId.of(documentIdInt);
 		if (documentId.isNew())
@@ -58,12 +58,12 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final RepoIdAware documentRepoId)
+	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final RepoIdAware documentRepoId)
 	{
 		return rootDocumentPath(windowId, documentRepoId.getRepoId());
 	}
 
-	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final String documentIdStr)
+	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, final String documentIdStr)
 	{
 		final DocumentId documentId = DocumentId.of(documentIdStr);
 		if (documentId.isNew())
@@ -73,7 +73,7 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static final DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
+	public static DocumentPath rootDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
 	{
 		if (documentId.isNew())
 		{
@@ -82,7 +82,7 @@ public final class DocumentPath
 		return new DocumentPath(DocumentType.Window, windowId.toDocumentId(), documentId);
 	}
 
-	public static final DocumentPath rootDocumentPath(final DocumentType documentType, final DocumentId documentTypeId, final DocumentId documentId)
+	public static DocumentPath rootDocumentPath(final DocumentType documentType, final DocumentId documentTypeId, final DocumentId documentId)
 	{
 		if (documentId == null || documentId.isNew())
 		{
@@ -92,7 +92,7 @@ public final class DocumentPath
 		return new DocumentPath(documentType, documentTypeId, documentId);
 	}
 
-	public static final List<DocumentPath> rootDocumentPathsList(final WindowId windowId, final String documentIdsListStr)
+	public static List<DocumentPath> rootDocumentPathsList(final WindowId windowId, final String documentIdsListStr)
 	{
 		if (documentIdsListStr == null || documentIdsListStr.isEmpty())
 		{
@@ -105,7 +105,7 @@ public final class DocumentPath
 				.collect(GuavaCollectors.toImmutableList());
 	}
 
-	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, final String idStr, final String detailId, final String rowIdStr)
+	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, final String idStr, final String detailId, final String rowIdStr)
 	{
 		if (Check.isEmpty(detailId, true))
 		{
@@ -124,7 +124,7 @@ public final class DocumentPath
 				.build();
 	}
 
-	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId, @NonNull final DocumentId rowId)
+	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId, @NonNull final DocumentId rowId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -134,7 +134,7 @@ public final class DocumentPath
 				.build();
 	}
 
-	public static final DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId)
+	public static DocumentPath includedDocumentPath(@NonNull final WindowId windowId, @NonNull final DocumentId documentId, @NonNull final DetailId detailId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -147,7 +147,7 @@ public final class DocumentPath
 	/**
 	 * Creates the path of a single document (root document or included document).
 	 */
-	public static final DocumentPath singleWindowDocumentPath(@NonNull final WindowId windowId, final DocumentId id, final DetailId detailId, final DocumentId rowId)
+	public static DocumentPath singleWindowDocumentPath(@NonNull final WindowId windowId, final DocumentId id, final DetailId detailId, final DocumentId rowId)
 	{
 		return builder()
 				.setDocumentType(windowId)
@@ -289,18 +289,6 @@ public final class DocumentPath
 	public WindowId getWindowIdOrNull()
 	{
 		return documentType == DocumentType.Window ? WindowId.of(documentTypeId) : null;
-	}
-
-	public int getAD_Window_ID(final int returnIfNotAvailable)
-	{
-		if (documentType == DocumentType.Window)
-		{
-			return documentTypeId.toIntOr(returnIfNotAvailable);
-		}
-		else
-		{
-			return returnIfNotAvailable;
-		}
 	}
 
 	public AdWindowId getAdWindowIdOrNull()

--- a/src/main/java/de/metas/ui/web/window/datatypes/WindowId.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/WindowId.java
@@ -1,5 +1,7 @@
 package de.metas.ui.web.window.datatypes;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 
@@ -9,6 +11,7 @@ import com.google.common.base.Preconditions;
 
 import de.metas.util.Check;
 import lombok.EqualsAndHashCode;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -35,12 +38,12 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public final class WindowId
 {
-	public static final WindowId fromJson(final String json)
+	public static WindowId fromJson(final String json)
 	{
 		return new WindowId(json);
 	}
 
-	public static final WindowId fromNullableJson(final String json)
+	public static WindowId fromNullableJson(final String json)
 	{
 		if (json == null)
 		{
@@ -49,9 +52,14 @@ public final class WindowId
 		return new WindowId(json);
 	}
 
-	public static final WindowId of(final int windowIdInt)
+	public static WindowId of(final int windowIdInt)
 	{
 		return new WindowId(windowIdInt);
+	}
+
+	public static WindowId of(@NonNull final AdWindowId adWindowId)
+	{
+		return new WindowId(adWindowId.getRepoId());
 	}
 
 	public static WindowId of(final DocumentId documentTypeId)
@@ -66,13 +74,9 @@ public final class WindowId
 		}
 	}
 
-	public static final WindowId ofIntOrNull(final int windowIdInt)
+	public static WindowId ofNullable(@Nullable final AdWindowId adWindowId)
 	{
-		if (windowIdInt <= 0)
-		{
-			return null;
-		}
-		return new WindowId(windowIdInt);
+		return adWindowId != null ? new WindowId(adWindowId.getRepoId()) : null;
 	}
 
 	private final String value;
@@ -138,6 +142,11 @@ public final class WindowId
 	public AdWindowId toAdWindowIdOrNull()
 	{
 		return AdWindowId.ofRepoIdOrNull(toIntOr(-1));
+	}
+
+	public AdWindowId toAdWindowId()
+	{
+		return AdWindowId.ofRepoId(toInt());
 	}
 
 	public boolean isInt()

--- a/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
@@ -22,6 +22,7 @@ import org.adempiere.ad.callout.api.impl.NullCalloutExecutor;
 import org.adempiere.ad.callout.spi.ICalloutProvider;
 import org.adempiere.ad.callout.spi.ImmutablePlainCalloutProvider;
 import org.adempiere.ad.element.api.AdTabId;
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ConstantLogicExpression;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.ad.ui.api.ITabCalloutFactory;
@@ -795,10 +796,9 @@ public class DocumentEntityDescriptor
 			return this;
 		}
 
-		public Builder setDocumentType(final DocumentType documentType, final int documentTypeIdInt)
+		public Builder setDocumentType(@NonNull final AdWindowId adWindowId)
 		{
-			setDocumentType(documentType, DocumentId.of(documentTypeIdInt));
-			return this;
+			return setDocumentType(DocumentType.Window, DocumentId.of(adWindowId.getRepoId()));
 		}
 
 		public DocumentType getDocumentType()

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/ADTabLoader.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/ADTabLoader.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.window.descriptor.factory.standard;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.compiere.model.GridTabVO;
 import org.compiere.model.GridWindowVO;
 
@@ -36,7 +37,7 @@ import lombok.Value;
 @Builder
 public class ADTabLoader
 {
-	int adWindowId;
+	AdWindowId adWindowId;
 
 	@NonNull
 	LayoutFactory rootLayoutFactory;

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorFactory.java
@@ -76,7 +76,7 @@ public class DefaultDocumentDescriptorFactory implements DocumentDescriptorFacto
 	private DefaultDocumentDescriptorLoader createDocumentDescriptorLoader(@NonNull final WindowId windowId)
 	{
 		return new DefaultDocumentDescriptorLoader(
-				windowId.toInt(),
+				windowId.toAdWindowId(),
 				dataEntrySubTabBindingDescriptorBuilder);
 	}
 

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorLoader.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultDocumentDescriptorLoader.java
@@ -49,7 +49,7 @@ import lombok.NonNull;
 
 	//
 	// Parameters
-	private final int AD_Window_ID;
+	private final AdWindowId adWindowId;
 
 	private final DataEntrySubTabBindingDescriptorBuilder dataEntrySubTabBindingDescriptorBuilder;
 
@@ -59,10 +59,10 @@ import lombok.NonNull;
 
 
 	/* package */ DefaultDocumentDescriptorLoader(
-			final int AD_Window_ID,
+			final AdWindowId adWindowId,
 			@NonNull final DataEntrySubTabBindingDescriptorBuilder dataEntrySubTabBindingDescriptorBuilder)
 	{
-		this.AD_Window_ID = AD_Window_ID;
+		this.adWindowId = adWindowId;
 		this.dataEntrySubTabBindingDescriptorBuilder = dataEntrySubTabBindingDescriptorBuilder;
 	}
 
@@ -75,20 +75,20 @@ import lombok.NonNull;
 		}
 		_executed = true;
 
-		if (AD_Window_ID <= 0)
+		if (adWindowId == null)
 		{
-			throw new DocumentLayoutBuildException("No window found for AD_Window_ID=" + AD_Window_ID);
+			throw new DocumentLayoutBuildException("No window found for AD_Window_ID=" + adWindowId);
 		}
 
 		final Stopwatch stopwatch = Stopwatch.createStarted();
 
-		final GridWindowVO gridWindowVO = DocumentLoaderUtil.createGridWindoVO(AD_Window_ID);
+		final GridWindowVO gridWindowVO = DocumentLoaderUtil.createGridWindoVO(adWindowId);
 		Check.assumeNotNull(gridWindowVO, "Parameter gridWindowVO is not null"); // shall never happen
 
 		final DocumentDescriptor.Builder documentBuilder = DocumentDescriptor.builder();
 
 		final DocumentLayoutDescriptor.Builder layoutBuilder = DocumentLayoutDescriptor.builder()
-				.setWindowId(WindowId.of(gridWindowVO.getAD_Window_ID()))
+				.setWindowId(WindowId.of(gridWindowVO.getAdWindowId()))
 				.setStopwatch(stopwatch)
 				.putDebugProperty("generator-name", toString());
 
@@ -109,10 +109,8 @@ import lombok.NonNull;
 					.setDocActionElement(rootLayoutFactory.createSpecialElement_DocStatusAndDocAction());
 		}
 
-		final AdWindowId adWindowId = AdWindowId.ofRepoId(AD_Window_ID);
-
 		ADTabLoader.builder()
-				.adWindowId(adWindowId.getRepoId())
+				.adWindowId(adWindowId)
 				.rootLayoutFactory(rootLayoutFactory)
 				.layoutBuilder(layoutBuilder)
 				.build()

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DocumentLoaderUtil.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DocumentLoaderUtil.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.window.descriptor.factory.standard;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.compiere.model.GridWindowVO;
 import org.compiere.util.Env;
 
@@ -30,12 +31,12 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class DocumentLoaderUtil
 {
-	public GridWindowVO createGridWindoVO(final int AD_Window_ID)
+	public GridWindowVO createGridWindoVO(final AdWindowId adWindowId)
 	{
 		final GridWindowVO gridWindowVO = GridWindowVO.builder()
 				.ctx(Env.getCtx())
 				.windowNo(0) // TODO: get rid of WindowNo from GridWindowVO
-				.adWindowId(AD_Window_ID)
+				.adWindowId(adWindowId)
 				.adMenuId(-1) // N/A
 				.loadAllLanguages(true)
 				.applyRolePermissions(false)

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
@@ -39,7 +39,6 @@ import de.metas.ui.web.process.ProcessId;
 import de.metas.ui.web.session.WebRestApiContextProvider;
 import de.metas.ui.web.window.WindowConstants;
 import de.metas.ui.web.window.datatypes.DataTypes;
-import de.metas.ui.web.window.datatypes.DocumentType;
 import de.metas.ui.web.window.descriptor.ButtonFieldActionDescriptor;
 import de.metas.ui.web.window.descriptor.ButtonFieldActionDescriptor.ButtonFieldActionType;
 import de.metas.ui.web.window.descriptor.DetailId;
@@ -212,7 +211,7 @@ import lombok.NonNull;
 		//
 		// Entity descriptor
 		final DocumentEntityDescriptor.Builder entityDescriptorBuilder = DocumentEntityDescriptor.builder()
-				.setDocumentType(DocumentType.Window, gridTabVO.getAD_Window_ID())
+				.setDocumentType(gridTabVO.getAdWindowId())
 				.setDetailId(detailId)
 				.setInternalName(gridTabVO.getInternalName())
 				//

--- a/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/LayoutFactory.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import org.adempiere.ad.element.api.AdTabId;
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
@@ -117,7 +118,7 @@ public class LayoutFactory
 	//
 	// Parameters
 	private final GridTabVOBasedDocumentEntityDescriptorFactory descriptorsFactory;
-	private final int _adWindowId;
+	private final AdWindowId _adWindowId;
 	private final ITranslatableString windowCaption;
 
 	private final ImmutableSet<Integer> childAdTabIdsToSkip;
@@ -134,7 +135,7 @@ public class LayoutFactory
 	{
 		SpringContextHolder.instance.autowire(this);
 
-		_adWindowId = gridTabVO.getAD_Window_ID();
+		_adWindowId = gridTabVO.getAdWindowId();
 		windowCaption = TranslatableStrings.ofMap(gridWindowVO.getNameTrls(), gridWindowVO.getName());
 
 		final AdTabId templateTabId = AdTabId.ofRepoId(CoalesceUtil.firstGreaterThanZero(gridTabVO.getTemplateTabId(), gridTabVO.getAD_Tab_ID()));
@@ -205,7 +206,7 @@ public class LayoutFactory
 				.flatMap(uiElementGroup -> getUIProvider().getUIElements(uiElementGroup).stream());
 	}
 
-	private int getAD_Window_ID()
+	private AdWindowId getAdWindowId()
 	{
 		return _adWindowId;
 	}
@@ -687,7 +688,7 @@ public class LayoutFactory
 	public final ViewLayout layoutSideListView()
 	{
 		final ViewLayout.Builder layoutBuilder = ViewLayout.builder()
-				.setWindowId(WindowId.of(getAD_Window_ID()))
+				.setWindowId(WindowId.of(getAdWindowId()))
 				.setEmptyResultText(HARDCODED_TAB_EMPTY_RESULT_TEXT)
 				.setEmptyResultHint(HARDCODED_TAB_EMPTY_RESULT_HINT);
 

--- a/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
+++ b/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlLookupDescriptor.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.ICachedStringExpression;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.api.TranslatableParameterizedStringExpression;
@@ -78,17 +79,17 @@ import de.metas.util.Check;
 @Immutable
 public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 {
-	public static final Builder builder()
+	public static Builder builder()
 	{
 		return new Builder();
 	}
 
-	public static final SqlLookupDescriptor cast(final LookupDescriptor descriptor)
+	public static SqlLookupDescriptor cast(final LookupDescriptor descriptor)
 	{
 		return (SqlLookupDescriptor)descriptor;
 	}
 
-	public static final LookupDescriptorProvider searchInTable(final String lookupTableName)
+	public static LookupDescriptorProvider searchInTable(final String lookupTableName)
 	{
 		return builder()
 				.setCtxTableName(null) // tableName
@@ -98,7 +99,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 				.buildProvider();
 	}
 
-	public static final LookupDescriptorProvider listByAD_Reference_Value_ID(final int AD_Reference_Value_ID)
+	public static LookupDescriptorProvider listByAD_Reference_Value_ID(final int AD_Reference_Value_ID)
 	{
 		Check.assumeGreaterThanZero(AD_Reference_Value_ID, "AD_Reference_Value_ID");
 
@@ -115,7 +116,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 	 * @param AD_Reference_Value_ID has to be > 0
 	 * @param AD_Val_Rule_ID may be <= 0
 	 */
-	public static final LookupDescriptorProvider searchByAD_Val_Rule_ID(
+	public static LookupDescriptorProvider searchByAD_Val_Rule_ID(
 			final int AD_Reference_Value_ID,
 			final int AD_Val_Rule_ID)
 	{
@@ -148,11 +149,10 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 	private final boolean highVolume;
 	private final boolean numericKey;
-	private final LookupSource lookupSourceType;
 
+	private final LookupSource lookupSourceType;
 	private final ImmutableSet<String> dependsOnFieldNames;
 	private final ImmutableSet<String> dependsOnTableNames;
-
 	private final GenericSqlLookupDataSourceFetcher lookupDataSourceFetcher;
 
 	private SqlLookupDescriptor(final Builder builder)
@@ -167,11 +167,10 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		numericKey = builder.numericKey;
 		highVolume = builder.isHighVolume();
-		lookupSourceType = builder.getLookupSourceType();
 
+		lookupSourceType = builder.getLookupSourceType();
 		dependsOnFieldNames = ImmutableSet.copyOf(builder.dependsOnFieldNames);
 		dependsOnTableNames = ImmutableSet.copyOf(builder.getDependsOnTableNames());
-
 		lookupDataSourceFetcher = GenericSqlLookupDataSourceFetcher.of(this); // keep it last!
 	}
 
@@ -181,6 +180,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 		return MoreObjects.toStringHelper(this)
 				.omitNullValues()
 				.add("tableName", tableName)
+				.add("zoomIntoWindowId", zoomIntoWindowId.orElse(null))
 				.add("highVolume", highVolume ? highVolume : null)
 				.add("sqlForFetching", sqlForFetchingExpression.toOneLineString())
 				.add("postQueryPredicate", postQueryPredicate == null || postQueryPredicate == INamePairPredicate.NULL ? null : postQueryPredicate)
@@ -192,6 +192,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 	{
 		return Objects.hash(
 				tableName,
+				zoomIntoWindowId,
 				sqlForFetchingExpression,
 				sqlForFetchingLookupByIdExpression,
 				entityTypeIndex,
@@ -224,6 +225,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		final SqlLookupDescriptor other = (SqlLookupDescriptor)obj;
 		return Objects.equals(tableName, other.tableName)
+				&& Objects.equals(zoomIntoWindowId, other.zoomIntoWindowId)
 				&& Objects.equals(sqlForFetchingExpression, other.sqlForFetchingExpression)
 				&& Objects.equals(sqlForFetchingLookupByIdExpression, other.sqlForFetchingLookupByIdExpression)
 				&& entityTypeIndex == other.entityTypeIndex
@@ -347,11 +349,10 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 		private ICachedStringExpression sqlForFetchingLookupByIdExpression;
 		private int entityTypeIndex = -1;
 
-		private int zoomIntoWindowId = -1;
+		private AdWindowId zoomIntoAdWindowId = null;
 
 		private Builder()
 		{
-			super();
 		}
 
 		public LookupDescriptorProvider buildProvider()
@@ -470,7 +471,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			// Set the SQLs
 			{
 				sqlTableName = lookupInfo.getTableName();
-				zoomIntoWindowId = lookupInfo.getZoomAD_Window_ID_Override();
+				zoomIntoAdWindowId = lookupInfo.getZoomAD_Window_ID_Override();
 				sqlForFetchingExpression = buildSqlForFetching(lookupInfo, sqlWhereFinal, lookup_SqlOrderBy)
 						.caching();
 				sqlForFetchingLookupByIdExpression = buildSqlForFetchingById(lookupInfo)
@@ -549,7 +550,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			}
 		}
 
-		private static final IStringExpression buildSqlWhere(final MLookupInfo lookupInfo, final LookupScope scope, final IValidationRule validationRuleEffective)
+		private static IStringExpression buildSqlWhere(final MLookupInfo lookupInfo, final LookupScope scope, final IValidationRule validationRuleEffective)
 		{
 			final String tableName = lookupInfo.getTableName();
 			final String lookup_SqlWhere = lookupInfo.getWhereClauseSqlPart();
@@ -585,7 +586,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return sqlWhereFinal.build();
 		}
 
-		private static final IStringExpression buildSqlWhereClauseFromValidationRule(final IValidationRule validationRule, final LookupScope scope)
+		private static IStringExpression buildSqlWhereClauseFromValidationRule(final IValidationRule validationRule, final LookupScope scope)
 		{
 			final IStringExpression validationRuleWhereClause = validationRule.getPrefilterWhereClause();
 			if (validationRuleWhereClause.isNullExpression())
@@ -602,7 +603,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return validationRuleWhereClause;
 		}
 
-		private final IStringExpression buildSqlForFetching(final MLookupInfo lookupInfo, final IStringExpression sqlWhere, final String sqlOrderBy)
+		private IStringExpression buildSqlForFetching(final MLookupInfo lookupInfo, final IStringExpression sqlWhere, final String sqlOrderBy)
 		{
 			final String tableName = lookupInfo.getTableName();
 			return IStringExpression.composer()
@@ -721,8 +722,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 
 		public Optional<WindowId> getZoomIntoWindowId()
 		{
-			final WindowId windowId = zoomIntoWindowId > 0 ? WindowId.of(zoomIntoWindowId) : null;
-			return Optional.ofNullable(windowId);
+			return Optional.ofNullable(WindowId.ofNullable(zoomIntoAdWindowId));
 		}
 
 		private LookupSource getLookupSourceType()
@@ -737,7 +737,7 @@ public final class SqlLookupDescriptor implements ISqlLookupDescriptor
 			return this;
 		}
 
-		private final Access getRequiredAccess(final String tableName)
+		private Access getRequiredAccess(final String tableName)
 		{
 			if (requiredAccess != null)
 			{

--- a/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.ad.expression.api.LogicExpressionResult;
@@ -506,8 +507,9 @@ public class DocumentCollection
 		{
 			zoomWindowFinder = RecordZoomWindowFinder.newInstance(zoomIntoInfo.getTableName());
 		}
-		final int zoomInto_adWindowId = zoomWindowFinder.findAD_Window_ID();
-		if (zoomInto_adWindowId <= 0)
+		
+		final AdWindowId zoomInto_adWindowId = zoomWindowFinder.findAdWindowId().orElse(null);
+		if (zoomInto_adWindowId == null)
 		{
 			throw new EntityNotFoundException("No windowId found")
 					.setParameter("zoomIntoInfo", zoomIntoInfo);
@@ -750,7 +752,7 @@ public class DocumentCollection
 		InterfaceWrapperHelper.save(toPO);
 
 		final CopyRecordSupport childCRS = CopyRecordFactory.getCopyRecordSupport(tableName);
-		childCRS.setAD_Window_ID(fromDocumentPath.getAD_Window_ID(-1));
+		childCRS.setAdWindowId(fromDocumentPath.getAdWindowIdOrNull());
 		childCRS.setParentPO(toPO);
 		childCRS.setBase(true);
 		childCRS.copyRecord(fromPO, ITrx.TRXNAME_ThreadInherited);
@@ -817,13 +819,13 @@ public class DocumentCollection
 	@Immutable
 	private static final class DocumentKey
 	{
-		public static final DocumentKey of(final Document document)
+		public static DocumentKey of(final Document document)
 		{
 			final DocumentPath documentPath = document.getDocumentPath();
 			return ofRootDocumentPath(documentPath);
 		}
 
-		public static final DocumentKey ofRootDocumentPath(final DocumentPath documentPath)
+		public static DocumentKey ofRootDocumentPath(final DocumentPath documentPath)
 		{
 			if (!documentPath.isRootDocument())
 			{
@@ -836,7 +838,7 @@ public class DocumentCollection
 			return new DocumentKey(documentPath.getDocumentType(), documentPath.getDocumentTypeId(), documentPath.getDocumentId());
 		}
 
-		public static final DocumentKey of(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
+		public static DocumentKey of(@NonNull final WindowId windowId, @NonNull final DocumentId documentId)
 		{
 			return new DocumentKey(DocumentType.Window, windowId.toDocumentId(), documentId);
 		}

--- a/src/main/java/de/metas/ui/web/window/model/DocumentReferencesService.java
+++ b/src/main/java/de/metas/ui/web/window/model/DocumentReferencesService.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 
 import javax.annotation.Nullable;
 
+import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.ZoomInfoFactory;
@@ -88,7 +89,7 @@ public class DocumentReferencesService
 
 			final DocumentAsZoomSource zoomSource = new DocumentAsZoomSource(sourceDocument);
 
-			final ZoomInfo zoomInfo = ZoomInfoFactory.get().retrieveZoomInfo(zoomSource, targetWindowId.toInt());
+			final ZoomInfo zoomInfo = ZoomInfoFactory.get().retrieveZoomInfo(zoomSource, targetWindowId.toAdWindowId());
 			final ITranslatableString filterCaption = extractFilterCaption(sourceDocument);
 			return createDocumentReference(zoomInfo, filterCaption);
 		});
@@ -136,7 +137,7 @@ public class DocumentReferencesService
 				.id(zoomInfo.getId())
 				.internalName(zoomInfo.getInternalName())
 				.caption(zoomInfo.getLabel())
-				.windowId(WindowId.of(zoomInfo.getAD_Window_ID()))
+				.windowId(WindowId.of(zoomInfo.getAdWindowId()))
 				.documentsCount(zoomInfo.getRecordCount())
 				.filter(MQueryDocumentFilterHelper.createDocumentFilterFromMQuery(zoomInfo.getQuery(), filterCaption))
 				.loadDuration(zoomInfo.getRecordCountDuration())
@@ -148,7 +149,7 @@ public class DocumentReferencesService
 		private final Properties ctx;
 		private final Evaluatee evaluationContext;
 
-		private final int adWindowId;
+		private final AdWindowId adWindowId;
 		private final int adTableId;
 		private final int recordId;
 		private final String keyColumnName;
@@ -167,7 +168,7 @@ public class DocumentReferencesService
 			evaluationContext = document.asEvaluatee();
 
 			final DocumentEntityDescriptor entityDescriptor = document.getEntityDescriptor();
-			adWindowId = entityDescriptor.getWindowId().toInt();
+			adWindowId = entityDescriptor.getWindowId().toAdWindowId();
 			tableName = entityDescriptor.getTableName();
 
 			adTableId = Services.get(IADTableDAO.class).retrieveTableId(tableName);
@@ -231,7 +232,7 @@ public class DocumentReferencesService
 		}
 
 		@Override
-		public int getAD_Window_ID()
+		public AdWindowId getAD_Window_ID()
 		{
 			return adWindowId;
 		}


### PR DESCRIPTION
Fix NPE which broke SO, PO and other documents from having a default TargetDocumentType.

This happened because `org.adempiere.service.impl.ValuePreferenceBL#retrieveAllWindowPreferences` threw an error: `element cannot be mapped to a null key`, as we had windowIDs which were missing. Everything is handled now via `Optional`s


https://github.com/metasfresh/metasfresh/issues/5382