### PR TITLE
turned out to be tricky and unneeded; removed the field again

### DIFF
--- a/src/main/java/de/metas/ui/web/view/descriptor/annotation/ViewColumn.java
+++ b/src/main/java/de/metas/ui/web/view/descriptor/annotation/ViewColumn.java
@@ -106,8 +106,9 @@ public @interface ViewColumn
 
 			/**
 			 * The column shall <b>not</b> be displayed,<br>
-			 * unless the sysconfig with key = "{@link ViewColumnLayout#displayedSysConfigPrefix()}.fieldName" validates to {@code true}.
-			 * If there is no sysConfig that can be validated a boolean, then {@link #FALSE} is assumed.
+			 * unless the sys-config with key = "{@link ViewColumnLayout#displayedSysConfigPrefix()}.fieldName" validates to {@code true}.
+			 * The sysconfig may be overridden on client or org-level.
+			 * If there is no sys-config that can be validated to a boolean, then {@link #defaultDisplaySysConfig()} is assumed.
 			 */
 			SYSCONFIG
 		}
@@ -116,10 +117,10 @@ public @interface ViewColumn
 
 		Displayed displayed() default Displayed.TRUE;
 
-		boolean defaultDisplaySysConfig() default false;
-
-		/** See {@link Displayed#SYSCONFIG}. Null or empty strings mean {@link Displayed#FALSE}. */
+		/** See {@link Displayed#SYSCONFIG}. If it evaluates to {@code null} or empty string, then go with {@link #defaultDisplaySysConfig()}. */
 		String displayedSysConfigPrefix() default "";
+
+		boolean defaultDisplaySysConfig() default false;
 
 		/** Display sequence number */
 		int seqNo();

--- a/src/main/java/de/metas/ui/web/view/descriptor/annotation/ViewColumnHelper.java
+++ b/src/main/java/de/metas/ui/web/view/descriptor/annotation/ViewColumnHelper.java
@@ -315,7 +315,7 @@ public final class ViewColumnHelper
 			return Services.get(ISysConfigBL.class)
 					.getBooleanValue(
 							sysConfigKey,
-							false,
+							viewColumnLayout.defaultDisplaySysConfig(),
 							Env.getAD_Client_ID(),
 							Env.getAD_Org_ID(Env.getCtx()));
 		}

--- a/src/main/java/de/metas/ui/web/window/datatypes/DataTypes.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/DataTypes.java
@@ -425,6 +425,22 @@ public final class DataTypes
 				return lookupValue;
 			}
 		}
+		else if (value instanceof RepoIdAware)
+		{
+			final int valueInt = ((RepoIdAware)value).getRepoId();
+			if (lookupDataSource != null)
+			{
+				final LookupValue lookupValue = lookupDataSource.findById(valueInt);
+				return toIntegerLookupValue(lookupValue);
+			}
+			else
+			{
+				throw new ValueConversionException()
+						.setFromValue(value)
+						.setTargetType(IntegerLookupValue.class)
+						.setLookupDataSource(lookupDataSource);
+			}
+		}
 		else if (value instanceof Number)
 		{
 			final int valueInt = ((Number)value).intValue();
@@ -436,7 +452,10 @@ public final class DataTypes
 			}
 			else
 			{
-				throw new ValueConversionException();
+				throw new ValueConversionException()
+						.setFromValue(value)
+						.setTargetType(IntegerLookupValue.class)
+						.setLookupDataSource(lookupDataSource);
 			}
 		}
 		else if (value instanceof String)

--- a/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentChangedEvent.java
+++ b/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentChangedEvent.java
@@ -1,6 +1,7 @@
 package de.metas.ui.web.window.datatypes.json;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -175,6 +176,11 @@ public class JSONDocumentChangedEvent
 	public ZonedDateTime getValueAsZonedDateTime()
 	{
 		return DateTimeConverters.fromObjectToZonedDateTime(value);
+	}
+
+	public LocalDate getValueAsLocalDate()
+	{
+		return DateTimeConverters.fromObjectToLocalDate(value);
 	}
 
 	public IntegerLookupValue getValueAsIntegerLookupValue()

--- a/src/test/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactoryTest.java
+++ b/src/test/java/de/metas/ui/web/material/cockpit/rowfactory/MaterialCockpitRowFactoryTest.java
@@ -185,8 +185,8 @@ public class MaterialCockpitRowFactoryTest
 		final AttributeSetInstanceId asiId1 = AttributeSetInstanceId.ofRepoId(asi1.getM_AttributeSetInstance_ID());
 
 		final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
-		attributeSetInstanceBL.getCreateAttributeInstance(asi1, attr1_value1);
-		attributeSetInstanceBL.getCreateAttributeInstance(asi1, attr2_value1);
+		attributeSetInstanceBL.getCreateAttributeInstance(asiId1, attr1_value1);
+		attributeSetInstanceBL.getCreateAttributeInstance(asiId1, attr2_value1);
 
 		final AttributesKey attributesKeyWithAttr1_and_attr2 = AttributesKeys
 				.createAttributesKeyFromASIAllAttributes(asiId1)


### PR DESCRIPTION
* just finishing the refactoring
* minor fix in ViewColumnHelper
* DataTypes.convertToIntegerLookupValue now supports also RepoIdAware
* JSONDocumentChangedEvent now has a method getValueAsLocalDate

metasfresh/metasfresh#5821