### PR TITLE
Make metasfresh more robust in case of unspecified selections

### DIFF
--- a/src/main/java/de/metas/ui/web/invoicecandidate/process/C_Invoice_Candidate_ApproveForInvoicing.java
+++ b/src/main/java/de/metas/ui/web/invoicecandidate/process/C_Invoice_Candidate_ApproveForInvoicing.java
@@ -108,7 +108,7 @@ public class C_Invoice_Candidate_ApproveForInvoicing extends ViewBasedProcessTem
 	private final IQuery<I_C_Invoice_Candidate> retrieveInvoiceCandidatesToApproveQuery()
 	{
 		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = Services.get(IQueryBL.class).createQueryBuilder(I_C_Invoice_Candidate.class)
-				.filter(getProcessInfo().getQueryFilter())
+				.filter(getProcessInfo().getQueryFilterOrElseFalse())
 				.addOnlyActiveRecordsFilter()
 				.addNotEqualsFilter(I_C_Invoice_Candidate.COLUMN_Processed, true) // not processed
 				.addNotEqualsFilter(I_C_Invoice_Candidate.COLUMN_ApprovalForInvoicing, true) // not already approved

--- a/src/main/java/de/metas/ui/web/procurement/process/PMM_Purchase_Candidate_CreatePurchaseOrder.java
+++ b/src/main/java/de/metas/ui/web/procurement/process/PMM_Purchase_Candidate_CreatePurchaseOrder.java
@@ -61,7 +61,7 @@ public class PMM_Purchase_Candidate_CreatePurchaseOrder
 	protected String doIt() throws Exception
 	{
 		recordsEnqueued = PMM_GenerateOrders.prepareEnqueuing()
-				.filter(getProcessInfo().getQueryFilter())
+				.filter(getProcessInfo().getQueryFilterOrElseFalse())
 				.enqueue();
 		return MSG_OK;
 	}


### PR DESCRIPTION
* change ProcessInfo to force the dev to decide if she/he want's all or nothing in case no query filter is specified.
* fix compile errors by choosing "nothing" in all current cases
IMPORTANT: this is branched from the 5.132_last_christmas branch